### PR TITLE
Export submission metadata in OData output

### DIFF
--- a/lib/data/json.js
+++ b/lib/data/json.js
@@ -67,11 +67,35 @@ const hashId = (stack) => shasum(stack.map(([ field, iteration ]) => `${field.na
 };*/
 
 // manually extracts fields from a row into a js obj given a schema fieldlist.
+// NOTE: expects extended submission metadata, for exporting submitter metadata!
 const submissionToOData = (fields, table, submission, options = {}) => new Promise((resolve) => {
   // we track result separately from our tree/stack-state below. we only push to
   // result when it is actually a result, but we always build the whole structure
   // so that we track iteration counts correctly for idhash stability.
   const result = [];
+
+  // we always build a tree structure from root to track where we are, even if
+  // we are actually outputting some subtrees of it.
+  const root = { __id: submission.instanceId };
+
+  if (table === 'Submissions') {
+    // the instanceId and submission metadata we decorate onto every root row even
+    // though they are not part of the form's own schema. so rather than try to
+    // inject them into the xml transformation below, we just formulate them here
+    // in advance:
+    Object.assign(root, {
+      __system: {
+        submissionDate: submission.createdAt,
+        submitterId: submission.submitter.id.toString(), // => string for future-proofing
+        submitterName: submission.submitter.displayName
+      }
+    });
+
+    // we always return an array result, but if we want to return the root record
+    // we won't have a repeat step-in to seed the one record we'll return. so if
+    // that's the case, do some shuffling here and now.
+    result.push(root);
+  }
 
   // we will simply iterate up and down our schema tree along with the xml, so
   // we will keep a stack of our nested field contexts. it's a rudimentary
@@ -80,13 +104,8 @@ const submissionToOData = (fields, table, submission, options = {}) => new Promi
   // * dataStack tracks our position in the output json.
   // * iterationStack tracks our iterationcount in fieldStack-space (repeats and groups).
   const fieldStack = [{ name: 'Submissions', children: fields }];
-  const dataStack = [{ __id: submission.instanceId }];
+  const dataStack = [ root ];
   const iterationStack = [ submission.instanceId ];
-
-  // we always return an array result, but if we want to return the root record
-  // we won't have a repeat step-in to seed the one record we'll return. so if
-  // that's the case, do some shuffling here and now.
-  if (table === 'Submissions') result.push(ptr(dataStack));
 
   // now spin up our XML parser and let its SAX-like tree events drive our traversal.
   let droppedWrapper = false;

--- a/lib/model/instance/submission.js
+++ b/lib/model/instance/submission.js
@@ -110,7 +110,7 @@ out.Submission = Instance(({ PartialSubmission, Attachment, Blob, simply, submis
   static getById(formId, instanceId, extended) { return submissions.getById(formId, instanceId, extended); }
   static getAllByFormId(formId, extended) { return submissions.getAllByFormId(formId, extended); }
 
-  static streamRowsByFormId(formId) { return submissions.streamRowsByFormId(formId); }
+  static streamRowsByFormId(formId, extended) { return submissions.streamRowsByFormId(formId, extended); }
   static streamAttachmentsByFormId(formId) { return submissions.streamAttachmentsByFormId(formId); }
 
   static fields() { return submissionFields; }

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -8,8 +8,38 @@
 // except according to the terms contained in the LICENSE file.
 
 const Problem = require('../../util/problem');
-const { fieldsForJoin, joinRowToInstance, rowsToInstances, maybeFirst, translateProblem } = require('../../util/db');
+const { map } = require('ramda');
+const { fieldsForJoin, joinRowToInstance, maybeFirst, translateProblem } = require('../../util/db');
+const { mapStream } = require('../../util/stream');
 const { resolve } = require('../../util/promise');
+
+const deserializer = (extended = false, { Submission, Actor }) => ((extended === false)
+  ? ((submission) => new Submission(submission))
+  : joinRowToInstance('submission', {
+      submission: Submission,
+      submitter: Actor
+    }));
+
+// Just returns information from the Submissions table by default. The extended
+// version also expands the submitter property into a full Actor Instance.
+const base = (extended = false, condition = [], { db, Submission, Actor }) => ((extended === false)
+  ? db.select('*')
+    .from('submissions')
+    .where(condition)
+    .where({ deletedAt: null })
+    .orderBy('createdAt', 'desc')
+  : db.select(fieldsForJoin({
+    submission: { table: 'submissions', fields: Submission.fields() },
+    submitter: { table: 'actors', fields: Actor.fields() }
+  }))
+    .from('submissions')
+    .where(condition)
+    .where({ 'submissions.deletedAt': null })
+    .leftOuterJoin(
+      db.select('*').from('actors').as('actors'),
+      'submissions.submitter', 'actors.id'
+    )
+    .orderBy('submissions.createdAt', 'desc'));
 
 module.exports = {
   getById: (formId, instanceId, extended) => ({ submissions }) =>
@@ -18,12 +48,9 @@ module.exports = {
   getAllByFormId: (formId, extended) => ({ submissions }) =>
     submissions._get(extended, { formId }),
 
-  // TODO: if we have a lot of streams, this is a somewhat clumsy solution.
-  streamRowsByFormId: (formId) => ({ db }) =>
-    resolve(db.select('*').from('submissions')
-      .where({ formId })
-      .orderBy('createdAt', 'desc')
-      .stream()),
+  // TODO: if we have a lot of streams, the manual resolve() is a somewhat clumsy solution.
+  streamRowsByFormId: (formId, extended) => (container) =>
+    resolve(base(extended, { formId }, container).pipe(mapStream(deserializer(extended, container)))),
 
   // The attachment will already contain information about its relationship to this
   // Submission, as it is a join entity.
@@ -44,30 +71,7 @@ module.exports = {
       .join('blobs', 'blobs.id', 'attachments.blobId')
       .stream()),
 
-  // Just returns information from the Submissions table by default. The extended
-  // version also expands the submitter property into a full Actor Instance.
-  _get: (extended = false, condition = []) => ({ db, Submission, Actor }) => ((extended === false)
-    ? db.select('*')
-      .from('submissions')
-      .where(condition)
-      .where({ deletedAt: null })
-      .orderBy('createdAt', 'desc')
-      .then(rowsToInstances(Submission))
-    : db.select(fieldsForJoin({
-      submission: { table: 'submissions', fields: Submission.fields() },
-      submitter: { table: 'actors', fields: Actor.fields() }
-    }))
-      .from('submissions')
-      .where(condition)
-      .where({ 'submissions.deletedAt': null })
-      .leftOuterJoin(
-        db.select('*').from('actors').as('actors'),
-        'submissions.submitter', 'actors.id'
-      )
-      .orderBy('submissions.createdAt', 'desc')
-      .then((rows) => rows.map(joinRowToInstance('submission', {
-        submission: Submission,
-        submitter: Actor
-      }))))
+  _get: (extended, condition) => (container) =>
+    base(extended, condition, container).then(map(deserializer(extended, container))),
 };
 

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -22,7 +22,7 @@ module.exports = {
   streamRowsByFormId: (formId) => ({ db }) =>
     resolve(db.select('*').from('submissions')
       .where({ formId })
-      .orderBy('createdAt', 'asc')
+      .orderBy('createdAt', 'desc')
       .stream()),
 
   // The attachment will already contain information about its relationship to this

--- a/lib/outbound/odata.js
+++ b/lib/outbound/odata.js
@@ -180,7 +180,12 @@ const edmxTemplater = template(`<?xml version="1.0" encoding="UTF-8"?>
 </edmx:Edmx>`);
 
 // converts a single primitive field into a Property databag for templating.
-const typeMap = { int: 'Edm.Int64', decimal: 'Edm.Decimal', geopoint: 'Edm.GeographyPoint' };
+const typeMap = {
+  int: 'Edm.Int64',
+  decimal: 'Edm.Decimal',
+  geopoint: 'Edm.GeographyPoint',
+  dateTime: 'Edm.DateTimeOffset'
+};
 const fieldToProperty = (field) => ({ name: field.name, type: (typeMap[field.type] || 'Edm.String') });
 
 // recursively translates a set of fields representing a "table" (root or repeat

--- a/lib/outbound/odata.js
+++ b/lib/outbound/odata.js
@@ -110,6 +110,9 @@ const edmxTemplater = template(`<?xml version="1.0" encoding="UTF-8"?>
       <EntityType Name="{{name}}">
         <Key><PropertyRef Name="__id"/></Key>
         <Property Name="__id" Type="Edm.String"/>
+      {{#primary}}
+        <Property Name="__system" Type="{{fqdnBase}}.__system"/>
+      {{/primary}}
       {{#properties}}
         {{^navigation}}
         <Property Name="{{name}}" Type="{{type}}"/>
@@ -117,6 +120,11 @@ const edmxTemplater = template(`<?xml version="1.0" encoding="UTF-8"?>
       {{/properties}}
       </EntityType>
     {{/entityTypes}}
+      <ComplexType Name="__system">
+        <Property Name="submissionDate" Type="Edm.DateTimeOffset"/>
+        <Property Name="submitterId" Type="Edm.String"/>
+        <Property Name="submitterName" Type="Edm.String"/>
+      </ComplexType>
     {{#complexTypes}}
       <ComplexType Name="{{name}}">
       {{#properties}}

--- a/lib/resources/odata.js
+++ b/lib/resources/odata.js
@@ -37,7 +37,7 @@ module.exports = (service, { Form, Submission, env }) => {
     Form.getByXmlFormId(params[0]) // first regexp match
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('read', form)
-        .then(() => Submission.getById(form.id, params[1])
+        .then(() => Submission.getById(form.id, params[1], true)
           .then(getOrNotFound)
           .then((submission) => singleRowToOData(form, submission, domain, decodeURI(originalUrl), query))))));
 
@@ -46,7 +46,7 @@ module.exports = (service, { Form, Submission, env }) => {
     Form.getByXmlFormId(params.id)
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('read', form)
-        .then(() => Submission.streamRowsByFormId(form.id)
+        .then(() => Submission.streamRowsByFormId(form.id, true)
           .then((stream) => json(rowStreamToOData(form, params.table, domain, originalUrl, query, stream)))))));
 };
 

--- a/lib/util/stream.js
+++ b/lib/util/stream.js
@@ -1,0 +1,12 @@
+const { Transform } = require('stream');
+
+const mapStream = (f) => new Transform({
+  objectMode: true,
+  transform(row, _, done) {
+    this.push(f(row));
+    done();
+  }
+});
+
+module.exports = { mapStream };
+

--- a/test/integration/api/odata.js
+++ b/test/integration/api/odata.js
@@ -89,10 +89,19 @@ describe('api: /forms/:id.svc', () => {
         asAlice.get("/v1/forms/doubleRepeat.svc/Submissions('double')")
           .expect(200)
           .then(({ body }) => {
+            // have to manually check and clear the date for exact match:
+            body.value[0].__system.submissionDate.should.be.an.isoDate();
+            delete body.value[0].__system.submissionDate;
+
             body.should.eql({
               '@odata.context': 'http://localhost:8989/v1/forms/doubleRepeat.svc/$metadata#Submissions',
               value: [{
                 __id: "double",
+                __system: {
+                  // submissionDate is checked above!
+                  submitterId: '5',
+                  submitterName: 'Alice'
+                },
                 children: {},
                 meta: { instanceID: "double" },
                 name: "Vick"
@@ -172,22 +181,42 @@ describe('api: /forms/:id.svc', () => {
         asAlice.get('/v1/forms/withrepeat.svc/Submissions')
           .expect(200)
           .then(({ body }) => {
+            for (const idx of [ 0, 1, 2 ]) {
+              body.value[idx].__system.submissionDate.should.be.an.isoDate();
+              delete body.value[idx].__system.submissionDate;
+            }
+
             body.should.eql({
               '@odata.context': 'http://localhost:8989/v1/forms/withrepeat.svc/$metadata#Submissions',
               value: [{
                 __id: "three",
+                __system: {
+                  // submissionDate is checked above,
+                  submitterId: "5",
+                  submitterName: "Alice"
+                },
                 meta: { instanceID: "three" },
                 name: "Chelsea",
                 age: 38,
                 children: {}
               }, {
                 __id: "two",
+                __system: {
+                  // submissionDate is checked above,
+                  submitterId: "5",
+                  submitterName: "Alice"
+                },
                 meta: { instanceID: "two" },
                 name: "Bob",
                 age: 34,
                 children: {}
               }, {
                 __id: "one",
+                __system: {
+                  // submissionDate is checked above,
+                  submitterId: "5",
+                  submitterName: "Alice"
+                },
                 meta: { instanceID: "one" },
                 name: "Alice",
                 age: 30

--- a/test/integration/api/odata.js
+++ b/test/integration/api/odata.js
@@ -175,10 +175,11 @@ describe('api: /forms/:id.svc', () => {
             body.should.eql({
               '@odata.context': 'http://localhost:8989/v1/forms/withrepeat.svc/$metadata#Submissions',
               value: [{
-                __id: "one",
-                meta: { instanceID: "one" },
-                name: "Alice",
-                age: 30
+                __id: "three",
+                meta: { instanceID: "three" },
+                name: "Chelsea",
+                age: 38,
+                children: {}
               }, {
                 __id: "two",
                 meta: { instanceID: "two" },
@@ -186,11 +187,10 @@ describe('api: /forms/:id.svc', () => {
                 age: 34,
                 children: {}
               }, {
-                __id: "three",
-                meta: { instanceID: "three" },
-                name: "Chelsea",
-                age: 38,
-                children: {}
+                __id: "one",
+                meta: { instanceID: "one" },
+                name: "Alice",
+                age: 30
               }]
             });
           }))));
@@ -203,6 +203,11 @@ describe('api: /forms/:id.svc', () => {
             body.should.eql({
               '@odata.context': 'http://localhost:8989/v1/forms/withrepeat.svc/$metadata#Submissions.children.child',
               value: [{
+                __id: 'beaedcdba519e6e6b8037605c9ae3f6a719984fa',
+                '__Submissions-id': 'three',
+                name: 'Candace',
+                age: 2
+              }, {
                 __id: 'cf9a1b5cc83c6d6270c1eb98860d294eac5d526d',
                 '__Submissions-id': 'two',
                 name: 'Billy',
@@ -212,11 +217,6 @@ describe('api: /forms/:id.svc', () => {
                 '__Submissions-id': 'two',
                 name: 'Blaine',
                 age: 6
-              }, {
-                __id: 'beaedcdba519e6e6b8037605c9ae3f6a719984fa',
-                '__Submissions-id': 'three',
-                name: 'Candace',
-                age: 2
               }]
             });
           }))));
@@ -231,10 +231,10 @@ describe('api: /forms/:id.svc', () => {
               '@odata.context': 'http://localhost:8989/v1/forms/withrepeat.svc/$metadata#Submissions.children.child',
               '@odata.nextLink': "http://localhost:8989/v1/forms/withrepeat.svc/Submissions.children.child?%24skip=2",
               value: [{
-                __id: 'c76d0ccc6d5da236be7b93b985a80413d2e3e172',
+                __id: 'cf9a1b5cc83c6d6270c1eb98860d294eac5d526d',
                 '__Submissions-id': 'two',
-                name: 'Blaine',
-                age: 6
+                name: 'Billy',
+                age: 4
               }]
             });
           }))));

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -288,11 +288,11 @@ describe('api: /forms/:id/submissions', () => {
               const csv = result['simple.csv'].split('\n').map((row) => row.split(','));
               csv[0].should.eql([ 'SubmissionDate', 'meta-instanceID', 'name', 'age', 'KEY' ]);
               csv[1].shift().should.be.an.recentIsoDate();
-              csv[1].should.eql([ 'one','Alice','30','one' ]);
+              csv[1].should.eql([ 'three','Chelsea','38','three' ]);
               csv[2].shift().should.be.an.recentIsoDate();
               csv[2].should.eql([ 'two','Bob','34','two' ]);
               csv[3].shift().should.be.an.recentIsoDate();
-              csv[3].should.eql([ 'three','Chelsea','38','three' ]);
+              csv[3].should.eql([ 'one','Alice','30','one' ]);
               done();
             }))))));
 

--- a/test/unit/outbound/odata.js
+++ b/test/unit/outbound/odata.js
@@ -46,10 +46,16 @@ describe('odata message composition', () => {
       <EntityType Name="Submissions">
         <Key><PropertyRef Name="__id"/></Key>
         <Property Name="__id" Type="Edm.String"/>
+        <Property Name="__system" Type="org.opendatakit.user.simple.__system"/>
         <Property Name="meta" Type="org.opendatakit.user.simple.meta"/>
         <Property Name="name" Type="Edm.String"/>
         <Property Name="age" Type="Edm.Int64"/>
       </EntityType>
+      <ComplexType Name="__system">
+        <Property Name="submissionDate" Type="Edm.DateTimeOffset"/>
+        <Property Name="submitterId" Type="Edm.String"/>
+        <Property Name="submitterName" Type="Edm.String"/>
+      </ComplexType>
       <ComplexType Name="meta">
         <Property Name="instanceID" Type="Edm.String"/>
       </ComplexType>
@@ -68,6 +74,7 @@ describe('odata message composition', () => {
       <EntityType Name="Submissions">
         <Key><PropertyRef Name="__id"/></Key>
         <Property Name="__id" Type="Edm.String"/>
+        <Property Name="__system" Type="org.opendatakit.user.withrepeat.__system"/>
         <Property Name="meta" Type="org.opendatakit.user.withrepeat.meta"/>
         <Property Name="name" Type="Edm.String"/>
         <Property Name="age" Type="Edm.Int64"/>
@@ -80,6 +87,11 @@ describe('odata message composition', () => {
         <Property Name="name" Type="Edm.String"/>
         <Property Name="age" Type="Edm.Int64"/>
       </EntityType>
+      <ComplexType Name="__system">
+        <Property Name="submissionDate" Type="Edm.DateTimeOffset"/>
+        <Property Name="submitterId" Type="Edm.String"/>
+        <Property Name="submitterName" Type="Edm.String"/>
+      </ComplexType>
       <ComplexType Name="meta">
         <Property Name="instanceID" Type="Edm.String"/>
       </ComplexType>
@@ -108,6 +120,7 @@ describe('odata message composition', () => {
       <EntityType Name="Submissions">
         <Key><PropertyRef Name="__id"/></Key>
         <Property Name="__id" Type="Edm.String"/>
+        <Property Name="__system" Type="org.opendatakit.user.withrepeat.__system"/>
         <Property Name="meta" Type="org.opendatakit.user.withrepeat.meta"/>
         <Property Name="name" Type="Edm.String"/>
         <Property Name="age" Type="Edm.Int64"/>
@@ -120,6 +133,11 @@ describe('odata message composition', () => {
         <Property Name="name" Type="Edm.String"/>
         <Property Name="age" Type="Edm.Int64"/>
       </EntityType>
+      <ComplexType Name="__system">
+        <Property Name="submissionDate" Type="Edm.DateTimeOffset"/>
+        <Property Name="submitterId" Type="Edm.String"/>
+        <Property Name="submitterName" Type="Edm.String"/>
+      </ComplexType>
       <ComplexType Name="meta">
         <Property Name="instanceID" Type="Edm.String"/>
       </ComplexType>


### PR DESCRIPTION
See commits for more; includes the following structure (and associated schema metadata) in each root level JSON output:

```
__system: {
  submissionDate: '<iso date>',
  submitterId: '<int>',
  submitterName: '<string>'
}
```