### PR TITLE
new: limited cookie authentication.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -52,6 +52,8 @@ In order to log a `User` in to a new `Session`, you must provide their credentia
 
 For security reasons, the only possible results are success or failure. No detail is provided upon failure.
 
+Successful responses will come with an HTTP-Only, Secure-Only cookie. This cookie is primarily meant for use by the Central frontend, and we do not recommend relying upon it. It will only work on `GET` requests, and it will only work over HTTPS.
+
 + Attributes (object)
     + email (string, required) - The `User`'s full email address.
     + password (string, required) - The `User`'s password.

--- a/lib/http/middleware.js
+++ b/lib/http/middleware.js
@@ -35,24 +35,41 @@ const versionParser = (request, response, next) => {
 // Used as pre-middleware, and injects the appropriate session information given the
 // appropriate credentials. If the given credentials don't match a session, aborts
 // with a 401. If no credentials are given, injects an empty session.
-// TODO: probably a better home for this.
-// TODO: repetitive, but detangling it doesn't make it clearer.
-const sessionParser = ({ Session, User, Auth }) => (request, response, next) => {
+// TODO: repetitive, but deduping it makes it even harder to understand.
+const sessionParser = ({ Session, User, Auth }) => (request, response, rawNext) => {
+  // always set a nothing auth before bailing so the various bailout cases can just return.
+  const next = (x) => {
+    if (x == null) {
+      if (request.auth == null)
+        request.auth = new Auth();
+      rawNext();
+    } else {
+      rawNext(x);
+    }
+  };
+
   const authHeader = request.get('Authorization');
+  const authBySessionToken = (token, onFailure) => Session.getByBearerToken(token).point()
+    .then((session) => {
+      if (!session.isDefined()) return next(onFailure);
+
+      request.auth = new Auth({ _session: session });
+      next();
+    });
+
+  // Standard Bearer token auth:
   if (!isBlank(authHeader) && authHeader.startsWith('Bearer ')) {
-    // Standard Bearer token auth.
-    if ((request.auth != null) && request.auth.isAuthenticated()) return next(Problem.user.authenticationFailed());
+    // fail if the user attempts multiple authentication schemes:
+    if ((request.auth != null) && request.auth.isAuthenticated())
+      return next(Problem.user.authenticationFailed());
 
-    Session.getByBearerToken(authHeader.slice(7)).point()
-      .then((session) => {
-        if (!session.isDefined()) return next(Problem.user.authenticationFailed());
+    authBySessionToken(authHeader.slice(7), Problem.user.authenticationFailed());
 
-        request.auth = new Auth({ _session: session });
-        next();
-      });
+  // Basic Auth, which is allowed over HTTPS only:
   } else if (!isBlank(authHeader) && authHeader.startsWith('Basic ')) {
-    // Allow Basic auth over HTTPS only.
-    if ((request.auth != null) && request.auth.isAuthenticated()) return next(Problem.user.authenticationFailed());
+    // fail if the user attempts multiple authentication schemes:
+    if ((request.auth != null) && request.auth.isAuthenticated())
+      return next(Problem.user.authenticationFailed());
 
     // fail the request unless we are under HTTPS.
     // this logic does mean that if we are not under nginx it is possible to fool the server.
@@ -80,8 +97,28 @@ const sessionParser = ({ Session, User, Auth }) => (request, response, next) => 
           }
         }))
       .catch(next);
+
+  // Cookie Auth, which is more relaxed about not doing anything on failures
+  // (but will absolutely not work on anything but GET):
+  } else if ((request.get('Cookie') != null) && (request.method === 'GET')) {
+    // do nothing if the user attempts multiple authentication schemes:
+    if ((request.auth != null) && request.auth.isAuthenticated())
+      return next();
+
+    // fail the request unless we are under HTTPS.
+    if ((request.protocol !== 'https') && (request.get('x-forwarded-proto') !== 'https'))
+      return next();
+
+    // otherwise get the cookie contents.
+    const token = /session=([^;]+)(?:;|$)/.exec(request.get('Cookie'));
+    if (token == null)
+      return next();
+
+    // actually try to authenticate with it. no Problem on failure.
+    authBySessionToken(token[1]);
+
+  // No auth:
   } else {
-    request.auth = new Auth();
     next();
   }
 };

--- a/lib/model/instance/session.js
+++ b/lib/model/instance/session.js
@@ -24,7 +24,7 @@ module.exports = Instance(({ Actor, Session, simply, sessions }) => class {
   create() { return simply.create('sessions', this); }
   delete() { return simply.delete('sessions', this, 'token'); }
 
-  forApi() { return this.without('actorId'); }
+  forApi() { return this.without('actor', 'actorId'); }
 
   static fromActor(actor) {
     const expiresAt = new Date();

--- a/lib/resources/sessions.js
+++ b/lib/resources/sessions.js
@@ -7,12 +7,22 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
+const { DateTime } = require('luxon');
 const Problem = require('../util/problem');
 const { isBlank } = require('../util/util');
 const { verifyPassword } = require('../util/crypto');
 const { endpoint } = require('../http/endpoint');
 const { getOrReject } = require('../util/promise');
-const { success } = require('../util/http');
+const { success, withCookie } = require('../util/http');
+
+const withSessionCookie = withCookie('__Host-session');
+const cookieFor = (session) => [
+  session.token,
+  `Expires=${DateTime.fromJSDate(session.expiresAt).toHTTP()}`,
+  'SameSite=Strict',
+  'HttpOnly',
+  'Secure'
+].join('; ');
 
 module.exports = (service, { User, Session }) => {
 
@@ -25,10 +35,14 @@ module.exports = (service, { User, Session }) => {
     return User.getByEmail(email)
       .then(getOrReject(Problem.user.authenticationFailed()))
       .then((user) => verifyPassword(password, user.password)
-        .then((verified) => ((verified === true)
-          ? Session.fromActor(user.actor).create()
-          : Problem.user.authenticationFailed())));
+        .then((verified) => ((verified !== true)
+          ? Problem.user.authenticationFailed()
+          : Session.fromActor(user.actor).create()
+            .then((session) => withSessionCookie(cookieFor(session))(session)))));
   }));
+
+  service.get('/sessions/restore', endpoint(({ auth }) =>
+    auth.session().orElse(Problem.user.notFound())));
 
   // here we always throw a 403 even if the token doesn't exist to prevent
   // information leakage.
@@ -38,7 +52,7 @@ module.exports = (service, { User, Session }) => {
       .then(getOrReject(Problem.user.insufficientRights()))
       .then((token) => auth.canOrReject('endSession', token.actor)
         .then(() => token.delete())
-        .then(success))));
+        .then(() => withSessionCookie('null; Expires=Thu, 01 Jan 1970 00:00:00 GMT')(success)))));
 
 };
 

--- a/lib/resources/sessions.js
+++ b/lib/resources/sessions.js
@@ -18,6 +18,7 @@ const { success, withCookie } = require('../util/http');
 const withSessionCookie = withCookie('__Host-session');
 const cookieFor = (session) => [
   session.token,
+  'Path=/',
   `Expires=${DateTime.fromJSDate(session.expiresAt).toHTTP()}`,
   'SameSite=Strict',
   'HttpOnly',

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -67,6 +67,11 @@ const xml = contentType('application/xml');
 const atom = contentType('application/atom+xml');
 const json = contentType('application/json');
 
+const withCookie = (key) => (value) => (result) => (_, response) => {
+  response.set('Set-Cookie', `${key}=${value}`);
+  return result;
+};
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // URL HELPERS
@@ -91,7 +96,7 @@ const urlWithQueryParams = (urlStr, set = {}) => {
 module.exports = {
   isTrue, urlPathname,
   serialize,
-  success, contentType, xml, atom, json,
+  success, contentType, xml, atom, json, withCookie,
   urlWithQueryParams
 };
 

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -19,7 +19,7 @@ describe('api: /sessions', () => {
         .then(({ body, headers }) => {
           // i don't know why this becomes an array but i think superagent does it.
           const cookie = headers['set-cookie'][0];
-          const matches = /__Host-session=([^;]+); Expires=([^;]+); SameSite=Strict; HttpOnly; Secure/.exec(cookie);
+          const matches = /__Host-session=([^;]+); Path=\/; Expires=([^;]+); SameSite=Strict; HttpOnly; Secure/.exec(cookie);
           should.exist(matches);
           matches[1].should.equal(body.token);
           matches[2].should.equal(DateTime.fromISO(body.expiresAt).toHTTP());

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -1,4 +1,5 @@
 const should = require('should');
+const { DateTime } = require('luxon');
 const { testService } = require('../setup');
 
 describe('api: /sessions', () => {
@@ -9,6 +10,19 @@ describe('api: /sessions', () => {
         .expect(200)
         .then(({ body }) => {
           body.should.be.a.Session();
+        })));
+
+    it('should set cookie information when the session returns', testService((service) =>
+      service.post('/v1/sessions')
+        .send({ email: 'chelsea@opendatakit.org', password: 'chelsea' })
+        .expect(200)
+        .then(({ body, headers }) => {
+          // i don't know why this becomes an array but i think superagent does it.
+          const cookie = headers['set-cookie'][0];
+          const matches = /__Host-session=([^;]+); Expires=([^;]+); SameSite=Strict; HttpOnly; Secure/.exec(cookie);
+          should.exist(matches);
+          matches[1].should.equal(body.token);
+          matches[2].should.equal(DateTime.fromISO(body.expiresAt).toHTTP());
         })));
 
     it('should return a 401 if the password is wrong', testService((service) =>
@@ -27,6 +41,27 @@ describe('api: /sessions', () => {
       service.post('/v1/sessions')
         .expect(400)
         .then(({ body }) => body.details.should.eql({ expected: [ 'email', 'password' ], got: {} }))));
+  });
+
+  describe('/restore GET', () => {
+    it('should fail if no valid session exists', testService((service) =>
+      service.get('/v1/sessions/restore')
+        .set('X-Forwarded-Proto', 'https')
+        .set('Cookie', '__Host-session: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+        .expect(404)));
+
+    it('should return the active session if it exists', testService((service) =>
+      service.post('/v1/sessions')
+        .send({ email: 'alice@opendatakit.org', password: 'alice' })
+        .expect(200)
+        .then(({ body }) => service.get('/v1/sessions/restore')
+          .set('X-Forwarded-Proto', 'https')
+          .set('Cookie', '__Host-session=' + body.token)
+          .expect(200)
+          .then((restore) => {
+            restore.body.should.be.a.Session();
+            restore.body.token.should.equal(body.token);
+          }))));
   });
 
   describe('/:token DELETE', () => {
@@ -56,6 +91,21 @@ describe('api: /sessions', () => {
             .then(() => service.get('/v1/users/current') // actually doesn't matter which route; we get 401 due to broken auth.
               .set('Authorization', 'Bearer ' + token)
               .expect(401));
+        })));
+
+    it('should clear the cookie if successful', testService((service) =>
+      service.post('/v1/sessions')
+        .send({ email: 'alice@opendatakit.org', password: 'alice' })
+        .expect(200)
+        .then(({ body }) => {
+          const token = body.token;
+          return service.delete('/v1/sessions/' + token)
+            .set('Authorization', 'Bearer ' + token)
+            .expect(200)
+            .then(({ headers }) => {
+              const cookie = headers['set-cookie'][0];
+              cookie.should.match(/__Host-session=null/);
+            });
         })));
   });
 });

--- a/test/unit/http/middleware.js
+++ b/test/unit/http/middleware.js
@@ -187,6 +187,67 @@ describe('middleware', () => {
         });
       });
     });
+
+    describe('by cookie', () => {
+      it('should never try cookie auth over HTTP', () => {
+        const request = createRequest({ method: 'GET', headers: { Cookie: '__Host-session=alohomora' } });
+        return sessionParser({ Auth, Session: mockSession('alohomora') })(request, null, () => {
+          should.not.exist(request.auth._session);
+          should.not.exist(request.auth._actor);
+        });
+      });
+
+      it('should not throw an error if the cookie is invalid', () => {
+        const request = createRequest({
+          method: 'GET', headers: {
+            'X-Forwarded-Proto': 'https',
+            Cookie: 'please just let me in'
+          }
+        });
+        return sessionParser({ Auth, Session: mockSession('alohomora') })(request, null, () => {
+          should.not.exist(request.auth._session);
+          should.not.exist(request.auth._actor);
+        });
+      });
+
+      it('should not throw an error if the token is invalid', () => {
+        const request = createRequest({
+          method: 'GET', headers: {
+            'X-Forwarded-Proto': 'https',
+            Cookie: '__Host-session=letmein'
+          }
+        });
+        return sessionParser({ Auth, Session: mockSession('alohomora') })(request, null, () => {
+          should.not.exist(request.auth._session);
+          should.not.exist(request.auth._actor);
+        });
+      });
+
+      it('should never try cookie auth for non-GET requests', () => {
+        const request = createRequest({
+          method: 'POST', headers: {
+            'X-Forwarded-Proto': 'https',
+            Cookie: '__Host-session=alohomora'
+          }
+        });
+        return sessionParser({ Auth, Session: mockSession('alohomora') })(request, null, () => {
+          should.not.exist(request.auth._session);
+          should.not.exist(request.auth._actor);
+        });
+      });
+
+      it('should work for HTTPS GET requests', () => {
+        const request = createRequest({
+          method: 'GET', headers: {
+            'X-Forwarded-Proto': 'https',
+            Cookie: '__Host-session=alohomora'
+          }
+        });
+        return sessionParser({ Auth, Session: mockSession('alohomora') })(request, null, () => {
+          request.auth._session.should.eql(Option.of('session'));
+        });
+      });
+    });
   });
 });
 

--- a/test/unit/util/http.js
+++ b/test/unit/util/http.js
@@ -69,40 +69,40 @@ describe('util/http', () => {
 
   describe('format response helpers', () => {
     const { contentType, xml, atom, json } = http;
-    const mockRequest = () => ({ type: function(value) { this.contentType = value } });
+    const mockResponse = () => ({ type: function(value) { this.contentType = value } });
     it('should ultimately return the result', () => {
-      contentType()(42)(null, mockRequest()).should.equal(42);
+      contentType()(42)(null, mockResponse()).should.equal(42);
     });
 
     it('should assign the requested content-type', () => {
-      const request = mockRequest();
+      const request = mockResponse();
       contentType('mime/test')()(null, request);
       request.contentType.should.equal('mime/test');
     });
 
     it('should provide working shortcuts for common types', () => {
-      const request = mockRequest();
-      xml()(null, request);
-      request.contentType.should.equal('application/xml');
-      atom()(null, request);
-      request.contentType.should.equal('application/atom+xml');
-      json()(null, request);
-      request.contentType.should.equal('application/json');
+      const response = mockResponse();
+      xml()(null, response);
+      response.contentType.should.equal('application/xml');
+      atom()(null, response);
+      response.contentType.should.equal('application/atom+xml');
+      json()(null, response);
+      response.contentType.should.equal('application/json');
     });
   });
 
   describe('cookie setter', () => {
     const { withCookie } = http;
-    const mockRequest = () => ({ set: function(key, value) { this[key] = value; } });
+    const mockResponse = () => ({ set: function(key, value) { this[key] = value; } });
 
     it('should ultimately return the result', () => {
-      withCookie()()(42)(null, mockRequest()).should.equal(42);
+      withCookie()()(42)(null, mockResponse()).should.equal(42);
     });
 
     it('should assign the requested cookie', () => {
-      const request = mockRequest();
-      withCookie('mykey')('myvalue')(42)(null, request);
-      request['Set-Cookie'].should.equal('mykey=myvalue');
+      const response = mockResponse();
+      withCookie('mykey')('myvalue')(42)(null, response);
+      response['Set-Cookie'].should.equal('mykey=myvalue');
     });
   });
 

--- a/test/unit/util/http.js
+++ b/test/unit/util/http.js
@@ -91,6 +91,21 @@ describe('util/http', () => {
     });
   });
 
+  describe('cookie setter', () => {
+    const { withCookie } = http;
+    const mockRequest = () => ({ set: function(key, value) { this[key] = value; } });
+
+    it('should ultimately return the result', () => {
+      withCookie()()(42)(null, mockRequest()).should.equal(42);
+    });
+
+    it('should assign the requested cookie', () => {
+      const request = mockRequest();
+      withCookie('mykey')('myvalue')(42)(null, request);
+      request['Set-Cookie'].should.equal('mykey=myvalue');
+    });
+  });
+
   describe('urlWithQueryParams', () => {
     const { urlWithQueryParams } = http;
     it('should return only a pathname', () => {


### PR DESCRIPTION
* sets an HttpOnly, Secure only cookie on POST /sessions/new along with
  normal login path.
* HttpOnly so no JS access.
* only works over HTTPS even if user agent ignores Secure.
* only works on GET requests.
* clears cookie on DELETE /sessions/:token along with logout path.
* new GET /sessions/restore gets the current cookie and returns its
  session information if it is valid.