### PR TITLE
bug: invalid extant form definitions would fail the FA migration.

### DIFF
--- a/lib/model/migrations/20180727-03-add-form-attachments-table.js
+++ b/lib/model/migrations/20180727-03-add-form-attachments-table.js
@@ -24,10 +24,19 @@ const up = (knex) =>
     fa.index([ 'formId' ]);
   }).then(() => {
     const { all, simply, Form } = require('../package').withDefaults({ db: knex });
+    const { expectedFormAttachments } = require('../../data/schema');
+    const { uniq, pluck } = require('ramda');
 
     // now add all expected attachments on extant forms.
     return simply.transacting.getAll('forms', Form)
-      .then((forms) => all.do(forms.map((form) => form.createExpectedAttachments())))
+      .then((forms) => all.do(forms.map((form) => expectedFormAttachments(form.xml)
+        .then((expected) => {
+          if (uniq(pluck('name', expected)).length < expected.length) {
+            process.stderr.write(`WARNING: form ${form.xmlFormId} contains an attachment filename collision. It will not correctly support form attachments.`);
+            return Promise.resolve();
+          }
+          return form.createExpectedAttachments();
+        }))))
       .point();
   });
 


### PR DESCRIPTION
preflight the expected attachments so we don't attempt to run any invalid queries.