### PR TITLE
Address duplicate form attachments

### DIFF
--- a/lib/data/schema.js
+++ b/lib/data/schema.js
@@ -215,7 +215,22 @@ const expectedFormAttachments = (xml) => {
     // if we have an <input query= at all we expect an itemsets.csv file.
     const itemsets = hasItemsets.orElse(false) ? [{ type: 'file', name: 'itemsets.csv' }] : [];
 
-    return externalInstances.concat(mediaFiles).concat(itemsets);
+    // now we need to deduplicate our expected files. we consider type and name
+    // a composite key, and we only add such pairs once. but duplicate names with
+    // different types will be sent through, as they are different expectations.
+    // n.b. this function returns the /expected/ list of files. so removing a dupe:
+    // 1. fulfills the contract: that one file we expect to see once.
+    // 2. /allows/ the duplicated file as one entry: the database constraint will
+    //    eventually complain about duplicate filenames.
+    const seen = {};
+    const result = [];
+    for (const attachment of externalInstances.concat(mediaFiles).concat(itemsets)) {
+      if ((seen[attachment.name] == null) || (seen[attachment.name] !== attachment.type))
+        result.push(attachment);
+      seen[attachment.name] = attachment.type;
+    }
+
+    return result;
   });
 };
 

--- a/lib/model/migrations/20180727-03-add-form-attachments-table.js
+++ b/lib/model/migrations/20180727-03-add-form-attachments-table.js
@@ -24,10 +24,19 @@ const up = (knex) =>
     fa.index([ 'formId' ]);
   }).then(() => {
     const { all, simply, Form } = require('../package').withDefaults({ db: knex });
+    const { expectedFormAttachments } = require('../../data/schema');
+    const { uniq, pluck } = require('ramda');
 
     // now add all expected attachments on extant forms.
     return simply.transacting.getAll('forms', Form)
-      .then((forms) => all.do(forms.map((form) => form.createExpectedAttachments())))
+      .then((forms) => all.do(forms.map((form) => expectedFormAttachments(form.xml)
+        .then((expected) => {
+          if (uniq(pluck('name', expected)).length < expected.length) {
+            process.stderr.write(`WARNING: form ${form.xmlFormId} contains an attachment filename collision. It will not correctly support form attachments.`);
+            return Promise.resolve();
+          }
+          return form.createExpectedAttachments();
+        }))))
       .point();
   });
 

--- a/test/unit/data/schema.js
+++ b/test/unit/data/schema.js
@@ -545,6 +545,87 @@ describe('form schema', () => {
         attachments.should.eql([{ type: 'file', name: 'itemsets.csv' }]);
       }).point();
     });
+
+    it('should deduplicate identical (name, type) pairs', () => {
+      const xml = `
+        <?xml version="1.0"?>
+        <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+          <h:head>
+            <model>
+              <instance>
+                <data id="form">
+                  <name/>
+                  <age/>
+                  <hometown/>
+                </data>
+              </instance>
+              <bind nodeset="/data/name" type="string"/>
+              <bind type="int" nodeset="/data/age"/>
+              <bind nodeset="/data/hometown" type="select1"/>
+              <itext>
+                <translation default="true()" lang="en">
+                  <text id="/data/name:label">
+                    <value form="image">jr://images/name.jpg</value>
+                  </text>
+                  <text id="/data/age:label">
+                    <value form="image">jr://images/name.jpg</value>
+                  </text>
+                  <text id="/data/hometown:label">
+                    <value form="video">jr://video/hometown.mp4</value>
+                  </text>
+                </translation>
+              </itext>
+            </model>
+          </h:head>
+        </h:html>`;
+      return expectedFormAttachments(xml).then((attachments) => {
+        attachments.should.eql([
+          { type: 'image', name: 'name.jpg' },
+          { type: 'video', name: 'hometown.mp4' }
+        ]);
+      }).point();
+    });
+
+    it('should not deduplicate identical names with different types', () => {
+      const xml = `
+        <?xml version="1.0"?>
+        <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+          <h:head>
+            <model>
+              <instance>
+                <data id="form">
+                  <name/>
+                  <age/>
+                  <hometown/>
+                </data>
+              </instance>
+              <bind nodeset="/data/name" type="string"/>
+              <bind type="int" nodeset="/data/age"/>
+              <bind nodeset="/data/hometown" type="select1"/>
+              <itext>
+                <translation default="true()" lang="en">
+                  <text id="/data/name:label">
+                    <value form="image">jr://images/name.file</value>
+                  </text>
+                  <text id="/data/age:label">
+                    <value form="audio">jr://images/name.file</value>
+                  </text>
+                  <text id="/data/hometown:label">
+                    <value form="video">jr://video/hometown.mp4</value>
+                  </text>
+                </translation>
+              </itext>
+            </model>
+          </h:head>
+        </h:html>`;
+      return expectedFormAttachments(xml).then((attachments) => {
+        attachments.should.eql([
+          { type: 'image', name: 'name.file' },
+          { type: 'audio', name: 'name.file' },
+          { type: 'video', name: 'hometown.mp4' }
+        ]);
+      }).point();
+    });
   });
 });
 


### PR DESCRIPTION
1. If the same filename is seen multiple times in a form xml def _and_ the expected type each time is the same, only return that filename once from `expectedFormAttachments`. (This will make the database happy with these cases.)
2. If some form still has duplicate attachment violations even given this change, don't fail the initial migration, just bail out on supporting attachments for that form.