### PR TITLE
new: restore clustered server capability to run-server script.

### DIFF
--- a/lib/bin/run-server.js
+++ b/lib/bin/run-server.js
@@ -60,3 +60,7 @@ const term = () => exit.gracefulExitHandler(service, server, {
 process.on('SIGINT', term); // ^C
 process.on('SIGTERM', term);
 
+process.on('message', (message) => { // parent process.
+  if (message === 'shutdown') term();
+});
+


### PR DESCRIPTION
at some point, this existed in the codebase, but it fell out the bottom due to lack of use. now i've re-enabled it and subjected it to quite a beating over the course of two days as part of the benchmarking tests (including not just load but also many restarts) so i feel pretty confident in putting this back in and using it in prod.