### PR TITLE
rm+bug #125: remove HTTP Date header validation for OpenRosa.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -731,12 +731,10 @@ In practical usage, ODK survey clients like Collect will interact with Central i
 * The [Form XML download](/reference/forms-and-submissions/'-individual-form/retrieving-form-xml) endpoint, a part of the standard REST API for Forms, is linked in the Form Listing response and allows clients to then download the ODK XForms XML for each form.
 * The OpenRosa Submission API, [documented below](/reference/openrosa-endpoints/openrosa-form-submission-api), allows survey clients to submit new Submissions to any Form.
 
-As part of the **HTTP Request API** OpenRosa standards specification, there are two required headers for any request:
+Where the **HTTP Request API** OpenRosa standards specification requires two headers for any request, Central requires only one:
 
-* `X-OpenRosa-Version` must be set to exactly `1.0` or the request will be rejected.
-* `Date` must be set to a _valid_ date in [RFC 2616 3.3.1 HTTP Date format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date) or the request will be rejected.
-    * Dates _must be real dates_; supplying the wrong day of the week for a given date, for example, will fail. As a concession to Android quirkiness, text following the required `GMT` timezone designation will be ignored rather than rejected.
-    * On the other hand, ODK Central does not actually use the supplied Date for anything, and so any valid Date will work. It does not, for instance, have to be a current or recent Date.
+* `X-OpenRosa-Version` **must** be set to exactly `1.0` or the request will be rejected.
+* But Central does not require a `Date` header field. You may set it if you wish, but it will have no effect on Central.
 
 ## OpenRosa Form Listing API [GET /v1/formList]
 
@@ -761,13 +759,11 @@ If you haven't already, please take a look at the **HTTP Request API** notes abo
     + Headers
 
             X-OpenRosa-Version: 1.0
-            Date: Fri, 20 Apr 2018 02:03:48 GMT
 
 + Response 200 (text/xml)
     + Headers
 
             X-OpenRosa-Version: 1.0
-            Date: Fri, 20 Apr 2018 02:03:49 GMT
 
     + Body
 
@@ -794,7 +790,6 @@ If you haven't already, please take a look at the **HTTP Request API** notes abo
     + Headers
 
             X-OpenRosa-Version: 1.0
-            Date: Fri, 20 Apr 2018 02:03:49 GMT
 
     + Body
 
@@ -819,7 +814,6 @@ Some additional things to understand when using this API:
     + Headers
 
             X-OpenRosa-Version: 1.0
-            Date: Fri, 20 Apr 2018 02:03:48 GMT
 
     + Body
 
@@ -835,7 +829,6 @@ Some additional things to understand when using this API:
     + Headers
 
             X-OpenRosa-Version: 1.0
-            Date: Fri, 20 Apr 2018 02:03:49 GMT
 
     + Body
 
@@ -849,7 +842,6 @@ Some additional things to understand when using this API:
     + Headers
 
             X-OpenRosa-Version: 1.0
-            Date: Fri, 20 Apr 2018 02:03:49 GMT
 
     + Body
 
@@ -861,7 +853,6 @@ Some additional things to understand when using this API:
     + Headers
 
             X-OpenRosa-Version: 1.0
-            Date: Fri, 20 Apr 2018 02:03:49 GMT
 
     + Body
 
@@ -873,7 +864,6 @@ Some additional things to understand when using this API:
     + Headers
 
             X-OpenRosa-Version: 1.0
-            Date: Fri, 20 Apr 2018 02:03:49 GMT
 
     + Body
 
@@ -896,13 +886,11 @@ A Manifest document is available at this resource path for any form in the syste
     + Headers
 
             X-OpenRosa-Version: 1.0
-            Date: Fri, 20 Apr 2018 02:03:48 GMT
 
 + Response 200 (text/xml)
     + Headers
 
             X-OpenRosa-Version: 1.0
-            Date: Fri, 20 Apr 2018 02:03:49 GMT
 
     + Body
 
@@ -924,7 +912,6 @@ A Manifest document is available at this resource path for any form in the syste
     + Headers
 
             X-OpenRosa-Version: 1.0
-            Date: Fri, 20 Apr 2018 02:03:49 GMT
 
     + Body
 

--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -92,11 +92,6 @@ const openRosaEndpoint = (f) => (request, response, rawNext) => {
   const header = request.headers;
   if (header['x-openrosa-version'] !== '1.0')
     return next(Problem.user.invalidHeader({ field: 'X-OpenRosa-Version', value: header['x-openrosa-version'] }));
-  // ODK Collect does not actually produce RFC 850/1123-compliant dates, so we munge the
-  // date a little on its behalf:
-  const patchedDate = (header.date == null) ? null : header.date.replace(/GMT.*$/i, 'GMT');
-  if (DateTime.fromHTTP(patchedDate).isValid !== true)
-    return next(Problem.user.invalidHeader({ field: 'Date', value: header.date }));
 
   // we assume any OpenRosa endpoint will only be passed xml strings.
   const success = (result) => { response.status(result.code).send(result.body); };

--- a/test/integration/api/forms.js
+++ b/test/integration/api/forms.js
@@ -43,14 +43,12 @@ describe('api: /forms', () => {
       service.login('chelsea', (asChelsea) =>
         asChelsea.get('/v1/formlist')
           .set('X-OpenRosa-Version', '1.0')
-          .set('Date', DateTime.local().toHTTP())
           .expect(403))));
 
     it('should return form details as xml', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.get('/v1/formlist')
           .set('X-OpenRosa-Version', '1.0')
-          .set('Date', DateTime.local().toHTTP())
           .expect(200)
           .then(({ text, headers }) => {
             // Collect is particular about this:
@@ -86,7 +84,6 @@ describe('api: /forms', () => {
             .expect(200)
             .then(() => asAlice.get('/v1/formList')
               .set('X-OpenRosa-Version', '1.0')
-              .set('Date', DateTime.local().toHTTP())
               .expect(200)
               .then(({ text }) => {
                 text.should.equal(`<?xml version="1.0" encoding="UTF-8"?>
@@ -102,7 +99,6 @@ describe('api: /forms', () => {
           .expect(200)
           .then(() => asAlice.get('/v1/formList')
             .set('X-OpenRosa-Version', '1.0')
-            .set('Date', DateTime.local().toHTTP())
             .expect(200)
             .then(({ text }) => {
               const domain = config.get('default.env.domain');
@@ -232,14 +228,12 @@ describe('api: /forms', () => {
       service.login('chelsea', (asChelsea) =>
         asChelsea.get('/v1/forms/simple/manifest')
           .set('X-OpenRosa-Version', '1.0')
-          .set('Date', DateTime.local().toHTTP())
           .expect(403))));
 
     it('should return no files if no attachments exist', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.get('/v1/forms/simple/manifest')
           .set('X-OpenRosa-Version', '1.0')
-          .set('Date', DateTime.local().toHTTP())
           .expect(200)
           .then(({ text }) => {
             text.should.equal(`<?xml version="1.0" encoding="UTF-8"?>
@@ -259,7 +253,6 @@ describe('api: /forms', () => {
             .expect(200)
             .then(() => asAlice.get('/v1/forms/withAttachments/manifest')
               .set('X-OpenRosa-Version', '1.0')
-              .set('Date', DateTime.local().toHTTP())
               .expect(200)
               .then(({ text }) => {
                 const domain = config.get('default.env.domain');

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -1,5 +1,4 @@
 const should = require('should');
-const { DateTime } = require('luxon');
 const { testService } = require('../setup');
 const testData = require('../data');
 const { zipStreamToFiles } = require('../../util/zip');
@@ -18,7 +17,6 @@ describe('api: /submission', () => {
     it('should reject if no xml file is given', testService((service) =>
       service.post('/v1/submission')
         .set('X-OpenRosa-Version', '1.0')
-        .set('Date', DateTime.local().toHTTP())
         .set('Content-Type', 'text/xml')
         .send(testData.instances.simple2.one)
         .expect(400)
@@ -29,7 +27,6 @@ describe('api: /submission', () => {
     it('should reject if the xml is not valid', testService((service) =>
       service.post('/v1/submission')
         .set('X-OpenRosa-Version', '1.0')
-        .set('Date', DateTime.local().toHTTP())
         .attach('xml_submission_file', Buffer.from('<test'), { filename: 'data.xml' })
         .expect(400)
         .then(({ text }) => { text.should.match(/form ID xml attribute/i); })));
@@ -37,14 +34,12 @@ describe('api: /submission', () => {
     it('should return notfound if the form does not exist', testService((service) =>
       service.post('/v1/submission')
         .set('X-OpenRosa-Version', '1.0')
-        .set('Date', DateTime.local().toHTTP())
         .attach('xml_submission_file', Buffer.from('<data id="nonexistent"><field/></data>'), { filename: 'data.xml' })
         .expect(404)));
 
     it('should reject if the user cannot submit', testService((service) =>
       service.post('/v1/submission')
         .set('X-OpenRosa-Version', '1.0')
-        .set('Date', DateTime.local().toHTTP())
         .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
         .expect(403)));
 
@@ -55,7 +50,6 @@ describe('api: /submission', () => {
           .expect(200)
           .then(() => asAlice.post('/v1/submission')
             .set('X-OpenRosa-Version', '1.0')
-            .set('Date', DateTime.local().toHTTP())
             .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
             .expect(409)))));
 
@@ -63,7 +57,6 @@ describe('api: /submission', () => {
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/submission')
           .set('X-OpenRosa-Version', '1.0')
-          .set('Date', DateTime.local().toHTTP())
           .attach('xml_submission_file', Buffer.from('<data id="simple" version="-1"><orx:meta><orx:instanceID>one</orx:instanceID></orx:meta></data>'), { filename: 'data.xml' })
           .expect(400)
           .then(({ text }) => {
@@ -74,7 +67,6 @@ describe('api: /submission', () => {
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/submission')
           .set('X-OpenRosa-Version', '1.0')
-          .set('Date', DateTime.local().toHTTP())
           .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
           .expect(201)
           .then(({ text }) => {
@@ -93,7 +85,6 @@ describe('api: /submission', () => {
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/submission')
           .set('X-OpenRosa-Version', '1.0')
-          .set('Date', DateTime.local().toHTTP())
           .attach('file1.txt', Buffer.from('this is test file one'), { filename: 'file1.txt' })
           .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
           .attach('file2.txt', Buffer.from('this is test file two'), { filename: 'file2.txt' })
@@ -108,12 +99,10 @@ describe('api: /submission', () => {
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/submission')
           .set('X-OpenRosa-Version', '1.0')
-          .set('Date', DateTime.local().toHTTP())
           .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
           .expect(201)
           .then(() => asAlice.post('/v1/submission')
             .set('X-OpenRosa-Version', '1.0')
-            .set('Date', DateTime.local().toHTTP())
             .attach('xml_submission_file', Buffer.from('<data id="simple"><meta><instanceID>one</instanceID></meta></data>'), { filename: 'data.xml' })
             .expect(409)
             .then(({ text }) => {
@@ -124,13 +113,11 @@ describe('api: /submission', () => {
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/submission')
           .set('X-OpenRosa-Version', '1.0')
-          .set('Date', DateTime.local().toHTTP())
           .attach('file1.txt', Buffer.from('this is test file one'), { filename: 'file1.txt' })
           .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
           .expect(201)
           .then(() => asAlice.post('/v1/submission')
             .set('X-OpenRosa-Version', '1.0')
-            .set('Date', DateTime.local().toHTTP())
             .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
             .attach('file2.txt', Buffer.from('this is test file two'), { filename: 'file2.txt' })
             .expect(201)
@@ -144,7 +131,6 @@ describe('api: /submission', () => {
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/submission')
           .set('X-OpenRosa-Version', '1.0')
-          .set('Date', DateTime.local().toHTTP())
           .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
           .attach('file1.txt', Buffer.from('this is test file one'), { filename: 'file1.txt' })
           .attach('file1.txt', Buffer.from('this is test file two'), { filename: 'file2.txt' })
@@ -159,7 +145,6 @@ describe('api: /submission', () => {
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/submission')
           .set('X-OpenRosa-Version', '1.0')
-          .set('Date', DateTime.local().toHTTP())
           .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
           .attach('file1.txt', Buffer.from('this is test file one'), { filename: 'file1.txt' })
           .expect(201)
@@ -291,14 +276,12 @@ describe('api: /forms/:id/submissions', () => {
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/submission')
           .set('X-OpenRosa-Version', '1.0')
-          .set('Date', DateTime.local().toHTTP())
           .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
           .attach('file1.txt', Buffer.from('this is test file one'), { filename: 'file1.txt' })
           .attach('file2.txt', Buffer.from('this is test file two'), { filename: 'file2.txt' })
           .expect(201)
           .then(() => asAlice.post('/v1/submission')
             .set('X-OpenRosa-Version', '1.0')
-            .set('Date', DateTime.local().toHTTP())
             .attach('xml_submission_file', Buffer.from(testData.instances.simple.two), { filename: 'data.xml' })
             .attach('file1.txt', Buffer.from('this is test file three'), { filename: 'file1.txt' })
             .expect(201))
@@ -471,7 +454,6 @@ describe('api: /forms/:id/submissions', () => {
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/submission')
           .set('X-OpenRosa-Version', '1.0')
-          .set('Date', DateTime.local().toHTTP())
           .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
           .attach('file.txt', Buffer.from('this is test file one'), { filename: 'file.txt' })
           .expect(201)

--- a/test/unit/http/endpoint.js
+++ b/test/unit/http/endpoint.js
@@ -3,7 +3,6 @@ const { EventEmitter } = require('events');
 const { createRequest, createResponse } = require('node-mocks-http');
 const streamTest = require('streamtest').v2;
 const { identity } = require('ramda');
-const { DateTime } = require('luxon');
 
 const appRoot = require('app-root-path');
 const { finalize, endpoint, openRosaEndpoint, odataEndpoint, sendError } = require(appRoot + '/lib/http/endpoint');
@@ -137,8 +136,7 @@ describe('endpoints', () => {
     // TODO: perhaps swap out forOpenRosa checks for the response check via sendError, as
     // forOpenRosa is an internal routing detail.
     it('should reject requests lacking a version', (done) => {
-      const headers = { 'Date': DateTime.local().toHTTP() };
-      openRosaEndpoint(identity)(createRequest({ headers }), createResponse(), (error) => {
+      openRosaEndpoint(identity)(createRequest(), createResponse(), (error) => {
         error.forOpenRosa.isProblem.should.equal(true);
         error.forOpenRosa.problemDetails.field.should.equal('X-OpenRosa-Version');
         done();
@@ -154,25 +152,7 @@ describe('endpoints', () => {
       });
     });
 
-    it('should reject requests lacking a date', (done) => {
-      const headers = { 'X-OpenRosa-Version': '1.0' };
-      openRosaEndpoint(identity)(createRequest({ headers }), createResponse(), (error) => {
-        error.forOpenRosa.isProblem.should.equal(true);
-        error.forOpenRosa.problemDetails.field.should.equal('Date');
-        done();
-      });
-    });
-
-    it('should reject requests with an invalid date format', (done) => {
-      const headers = { 'X-OpenRosa-Version': '1.0', 'Date': '2012-12-12T12:12:12z' };
-      openRosaEndpoint(identity)(createRequest({ headers }), createResponse(), (error) => {
-        error.forOpenRosa.isProblem.should.equal(true);
-        error.forOpenRosa.problemDetails.field.should.equal('Date');
-        done();
-      });
-    });
-
-    const goodHeaders = { 'X-OpenRosa-Version': '1.0', 'Date': DateTime.local().toHTTP() };
+    const goodHeaders = { 'X-OpenRosa-Version': '1.0' };
     it('should wrap returned problems into an openrosa response format', (done) => {
       const problem = new Problem(400, 'test message');
       const response = createModernResponse();


### PR DESCRIPTION
* it turns out that Collect does not send RFC7231 dates (which only
  allow English), it sends dates constructed in that format by..
  presumably JodaTime, i haven't looked.
* what this means is that when Collect is set to some other language, it
  will send the text names in not-English. this in turn fails the Date
  validation check per OpenRosa.
  * technically OpenRosa does not specify RFC 7231, it just gives an
    example that looks like it. but the HTTP spec itself does specify
    this, and the Date header used is the same.
  * and the OpenRosa spec doesn't explain, either, that the Date /could/
    be in a non-English format.
* either way, the simple solution is to simply not validate the Date
  field anymore at all. Central doesn't actually care about it or use it
  for anything; it was implemented only to satisfy the specification.
* resolves #125.