### PR TITLE
Exclude 'xml' field when X-Extended-Metadata is false

### DIFF
--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -46,7 +46,7 @@ module.exports = {
   // the modifier allows custom chaining to be inserted into the query, which is used
   // above in getOpen().
   _get: (extended = false, modifier = identity) => ({ db, Form, Actor }) => ((extended === false)
-    ? db.select('*')
+    ? db.select(Form.fields().filter((field)=> field != 'xml'))
       .from('forms')
       .modify(modifier)
       .where({ deletedAt: null })


### PR DESCRIPTION
Closes #103 
Modified database select query to exclude `xml` field to produce the following response: 
```
[
    {
        "xmlFormId": "TestForm",
        "version": "",
        "state": "open",
        "hash": "155afd06b2531d726058a5c0ef726817",
        "name": "TestForm",
        "createdAt": "2018-10-07T07:59:22.389Z",
        "updatedAt": null
    }
]
```