### PR TITLE
improve #144: make email addresses case-insensitive everywhere.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Next, create a database and user in Postgres. Either use the same settings as th
 ```sql
 CREATE USER jubilant WITH PASSWORD 'jubilant';
 CREATE DATABASE jubilant with owner=jubilant encoding=UTF8;
+CREATE EXTENSION IF NOT EXISTS CITEXT;
 ```
 
 Then, go to the repository root in a command line (where this README is) and run `make` with no arguments. This will install all npm dependencies and run all necessary migrations on the database; see the [makefile](Makefile) for details.

--- a/lib/model/migrations/20181011-make-email-case-insensitive.js
+++ b/lib/model/migrations/20181011-make-email-case-insensitive.js
@@ -1,0 +1,9 @@
+const up = (db) => db.schema
+  .raw('create extension if not exists CITEXT')
+  .alterTable('users', (users) => users.specificType('email', 'CITEXT').notNullable().alter());
+
+const down = (db) => db
+  .alterTable('users', (users) => users.string('email', 320).notNullable().alter());
+
+module.exports = { up, down };
+

--- a/test/integration/api/sessions.js
+++ b/test/integration/api/sessions.js
@@ -12,6 +12,14 @@ describe('api: /sessions', () => {
           body.should.be.a.Session();
         })));
 
+    it('should treat email addresses case insensitively', testService((service) =>
+      service.post('/v1/sessions')
+        .send({ email: 'cHeLsEa@oPeNdAtAkIt.OrG', password: 'chelsea' })
+        .expect(200)
+        .then(({ body }) => {
+          body.should.be.a.Session();
+        })));
+
     it('should set cookie information when the session returns', testService((service) =>
       service.post('/v1/sessions')
         .send({ email: 'chelsea@opendatakit.org', password: 'chelsea' })


### PR DESCRIPTION
* the good news is that postgres offers this natively, so that you don't
  have to do 'UPPER('input')=UPPER(email)' all over the place, and so
  that the uniqueness constraint accounts for the case-insensitivity.
* the bad news is that it's offered via the CITEXT extension which is
  bundled but must be manually enabled.
* the worst news is that non-superusers cannot enable extensions, which
  crashes the migration.
* but as far as i know our user /is/ a superuser on docker and on
  circleci (which uses docker).
  * so those cases aren't issues.
  * and i've added a line in the README to manually add the extension at
    database creation.