### PR TITLE
bug #147: fix cases where groups/structures have <bind relevant=> nodes.

### DIFF
--- a/lib/data/schema.js
+++ b/lib/data/schema.js
@@ -81,7 +81,7 @@ const getFormSchema = (form) => {
   const modelNode = findOne(root('html'), node('head'), node('model'));
   return traverseXml(form.xml, [
     modelNode(findOne(root(), node('instance'), node())(tree())),
-    modelNode(findAll(root(), node('bind'))(attr())),
+    modelNode(findAll(root(), and(node('bind'), hasAttr('type')))(attr())),
     findOne(root('html'), node('body'))(findAll(node('repeat'))(attr('nodeset')))
   ]).then(([ instance, bindings, repeats ]) =>
     _recurseFormSchema(instance.get(), getList(bindings), getList(repeats)).children);

--- a/test/unit/data/schema.js
+++ b/test/unit/data/schema.js
@@ -136,6 +136,50 @@ describe('form schema', () => {
       }).point();
     });
 
+    it('should deal correctly with structure nodes with bindings', () => { // gh147
+      const xml = `
+        <?xml version="1.0"?>
+        <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+          <h:head>
+            <model>
+              <instance>
+                <data id="form">
+                  <name/>
+                  <occupation>
+                    <title/>
+                    <salary/>
+                    <dates>
+                      <joined/>
+                      <departed/>
+                    </dates>
+                  </occupation>
+                </data>
+              </instance>
+              <bind nodeset="/data/name" type="string"/>
+              <bind nodeset="/data/occupation" relevant="/data/name='liz'"/>
+              <bind nodeset="/data/occupation/title" type="string"/>
+              <bind nodeset="/data/occupation/salary" type="decimal"/>
+              <bind nodeset="/data/occupation/dates" relevant="true()"/>
+              <bind nodeset="/data/occupation/dates/joined" type="date"/>
+              <bind nodeset="/data/occupation/dates/departed" type="date"/>
+            </model>
+          </h:head>
+        </h:html>`;
+      return getFormSchema({ xml }).then((schema) => {
+        schema.should.eql([
+          { name: 'name', type: 'string' },
+          { name: 'occupation', type: 'structure', children: [
+            { name: 'title', type: 'string' },
+            { name: 'salary', type: 'decimal' },
+            { name: 'dates', type: 'structure', children: [
+              { name: 'joined', type: 'date' },
+              { name: 'departed', type: 'date' }
+            ] }
+          ] }
+        ]);
+      }).point();
+    });
+
     it('should deal correctly with repeats', () => {
       const xml = `
         <?xml version="1.0"?>


### PR DESCRIPTION
* or any <bind> node for that instance.
* just needed to filter out <bind> nodes that don't have type=; we only
  care about the type information.
* resolves #147.