### PR TITLE
improve #103: do not return Form or Submission XML unless Extended.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -388,7 +388,7 @@ It is not yet possible to modify a Form's XML definition once it is created.
 
 Currently, there are no paging or filtering options, so listing `Form`s will get you every Form in the system, every time.
 
-This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to additionally retrieve the `submissions` count of the number of `Submission`s that each Form has, as well as the `lastSubmission` most recent submission timestamp.
+This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to additionally retrieve the `submissions` count of the number of `Submission`s that each Form has, as well as the `lastSubmission` most recent submission timestamp and the actual `xml` XForms XML form definition backing the form.
 
 + Response 200 (application/json)
     This is the standard response, if Extended Metadata is not requested:
@@ -460,7 +460,7 @@ The API will currently check the XML's structure in order to extract the informa
 
 #### Getting Form Details [GET]
 
-This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to additionally retrieve the `submissions` count of the number of `Submission`s that this Form has, as well as the `lastSubmission` most recent submission timestamp.
+This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to additionally retrieve the `submissions` count of the number of `Submission`s that this Form has, as well as the `lastSubmission` most recent submission timestamp and the actual `xml` XForms XML form definition backing the form.
 
 + Response 200 (application/json)
     This is the standard response, if Extended Metadata is not requested:
@@ -670,7 +670,7 @@ Once created (which, like with Forms, is done by way of their XML data rather th
 
 Currently, there are no paging or filtering options, so listing `Submission`s will get you every Submission in the system, every time.
 
-This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to inflate the `submitter` from an `Actor` ID reference to an actual Actor metadata object.
+This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to inflate the `submitter` from an `Actor` ID reference to an actual Actor metadata object and return the actual `xml` submission XML data.
 
 + Response 200 (application/json)
     This is the standard response, if Extended Metadata is not requested:
@@ -708,7 +708,7 @@ To export all the `Submission` data associated with a `Form`, just add `.csv.zip
 
 Like how `Form`s are addressed by their XML `formId`, individual `Submission`s are addressed in the URL by their `instanceId`.
 
-This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to inflate the `submitter` from an `Actor` ID reference to an actual Actor metadata object.
+This endpoint supports retrieving extended metadata; provide a header `X-Extended-Metadata: true` to inflate the `submitter` from an `Actor` ID reference to an actual Actor metadata object and return the actual `xml` submission XML data.
 
 + Parameters
     + xmlFormId: `simple` (string, required) - The `xmlFormId` of the Form being referenced.
@@ -1305,13 +1305,13 @@ These are in alphabetic order, with the exception that the `Extended` versions o
 + version: `2.1` (string, optional) - The `version` of this form as given in its XForms XML definition. Empty string and `null` are treated equally as a single version.
 + hash: `51a93eab3a1974dbffc4c7913fa5a16a` (string, required) - An MD5 sum automatically computed based on the XForms XML definition. This is required for OpenRosa compliance.
 + state (Form State, required) - The present lifecycle status of this form. Controls whether it is available for download on survey clients or accepts new submissions.
-+ xml: `…` (string, required) - The XForms XML that defines this form.
 + createdAt: `2018-01-19T23:58:03.395Z` (string, required) - ISO date format
 + updatedAt: `2018-03-21T12:45:02.312Z` (string, optional) - ISO date format
 
 ## Extended Form (Form)
 + submissions: `10` (number, required) - The number of `Submission`s that have been submitted to this `Form`.
 + lastSubmission: `2018-04-18T03:04:51.695Z` (string, optional) - ISO date format. The timestamp of the most recent submission, if any.
++ xml: `…` (string, required) - The XForms XML that defines this form.
 
 ## Form Attachment (object)
 + name: `myfile.mp3` (string, required) - The name of the file as specified in the XForm.
@@ -1347,12 +1347,12 @@ These are in alphabetic order, with the exception that the `Extended` versions o
 ## Submission (object)
 + instanceId: `uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44` (string, required) - The `instanceId` of the `Submission`, given by the Submission XML.
 + submitter: `23` (number, required) - The ID of the `Actor` (`Field Key` or `User`) that submitted this `Submission`.
-+ xml: `…` (string, required) - The actual `Submission` XML.
 + createdAt: `2018-01-19T23:58:03.395Z` (string, required) - ISO date format
 + updatedAt: `2018-03-21T12:45:02.312Z` (string, optional) - ISO date format
 
 ## Extended Submission (Submission)
 + submitter (Actor, required) - The full details of the `Actor` that submitted this `Submission`.
++ xml: `…` (string, required) - The actual `Submission` XML.
 
 ## Success (object)
 + success: `true` (boolean, required)

--- a/docs/api.md
+++ b/docs/api.md
@@ -727,6 +727,23 @@ This endpoint supports retrieving extended metadata; provide a header `X-Extende
 + Response 403 (application/json)
     + Attributes (Error 403)
 
+#### Retrieving Submission XML [GET /v1/forms/{xmlFormId}/submissions/{instanceId}.xml]
+
+To get only the XML of the `Submission` rather than all of the details with the XML as one of many properties, just add `.xml` to the end of the request URL.
+
++ Parameters
+    + xmlFormId: `simple` (string, required) - The `xmlFormId` of the Form being referenced.
+    + instanceId: `uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44` (string, required) - The `instanceId` of the Submission being referenced.
+
++ Response 200 (application/xml)
+    + Body
+
+            <data id="simple">
+              <orx:meta><orx:instanceID>uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44</orx:instanceID></orx:meta>
+              <name>Alice</name>
+              <age>32</age>
+            </data>
+
 ## Attachments [/v1/forms/{xmlFormId}/submissions/{instanceId}/attachments]
 
 When `Submission`s are created via the OpenRosa `/submission` API, multimedia files can be attached. These might be, for example, photos or video taken as part of the survey. ODK Central keeps track of which files relate to which Submission, so that they may be reliably exported again. To directly retrieve them, you can use the `/attachments` subresource on the Submissions resource. It is only possible to list and download Attachments.

--- a/lib/model/instance/form.js
+++ b/lib/model/instance/form.js
@@ -48,7 +48,7 @@ const ExtendedForm = ExtendedInstance({
 module.exports = Instance.with(ActeeTrait, HasExtended(ExtendedForm))('forms', {
   all: [ 'id', 'xmlFormId', 'xml', 'version', 'state', 'hash', 'name', 'acteeId',
     'createdAt', 'updatedAt', 'deletedAt' ],
-  readable: [ 'xmlFormId', 'xml', 'version', 'state', 'hash', 'name', 'createdAt', 'updatedAt' ],
+  readable: [ 'xmlFormId', 'version', 'state', 'hash', 'name', 'createdAt', 'updatedAt' ],
   writable: [ 'name', 'state' ]
 })(({ all, simply, Form, FormAttachment, forms, formAttachments }) => class {
   forCreate() { return withCreateTime(this); }

--- a/lib/model/instance/submission.js
+++ b/lib/model/instance/submission.js
@@ -48,13 +48,18 @@ out.PartialSubmission = Instance()(({ Submission }) => class {
 
 /* eslint-disable */ // because its newline requirements here are insane.
 const ExtendedSubmission = ExtendedInstance({
+  fields: {
+    // TODO: would be nice not to have to redeclare fields.all just to change readable:
+    all: [ 'id', 'formId', 'instanceId', 'xml', 'submitter', 'createdAt', 'updatedAt', 'deletedAt' ],
+    readable: [ 'instanceId', 'xml', 'submitter', 'createdAt', 'updatedAt' ]
+  },
   forApi() { return merge(superproto(this).forApi(), { submitter: this.submitter.forApi() }); }
 });
 /* eslint-enable */
 
 out.Submission = Instance.with(HasExtended(ExtendedSubmission))('submissions', {
   all: [ 'id', 'formId', 'instanceId', 'xml', 'submitter', 'createdAt', 'updatedAt', 'deletedAt' ],
-  readable: [ 'instanceId', 'xml', 'submitter', 'createdAt', 'updatedAt' ]
+  readable: [ 'instanceId', 'submitter', 'createdAt', 'updatedAt' ]
 })(({ PartialSubmission, SubmissionAttachment, Blob, simply, submissions }) => class {
 
   forCreate() { return withCreateTime(this); }

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -76,7 +76,7 @@ module.exports = {
     deserializer: (extended = false) => ({ Submission, Actor }) => ((extended === false)
       ? ((submission) => new Submission(submission))
       : joinRowToInstance('submission', {
-        submission: Submission,
+        submission: Submission.Extended,
         submitter: Actor
       }))
   }

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -13,6 +13,7 @@ const sanitize = require('sanitize-filename');
 const { openRosaEndpoint, endpoint } = require('../http/endpoint');
 const { createdMessage } = require('../outbound/openrosa');
 const { getOrNotFound, getOrReject, rejectIf, resolve, reject } = require('../util/promise');
+const { xml } = require('../util/http');
 const Option = require('../util/option');
 const Problem = require('../util/problem');
 const { streamBriefcaseCsvs } = require('../data/briefcase');
@@ -111,6 +112,14 @@ module.exports = (service) => {
       .then(getOrNotFound)
       .then((form) => auth.canOrReject('read', form)
         .then(() => Submission.getAllByFormId(form.id, queryOptions)))));
+
+  service.get('/forms/:formId/submissions/:instanceId.xml', endpoint(({ Form, Submission }, { params, auth, queryOptions }) =>
+    Form.getByXmlFormId(params.formId)
+      .then(getOrNotFound)
+      .then((form) => auth.canOrReject('read', form)
+        .then(() => Submission.getById(form.id, params.instanceId, queryOptions))
+        .then(getOrNotFound)
+        .then((submission) => xml(submission.xml)))));
 
   service.get('/forms/:formId/submissions/:instanceId', endpoint(({ Form, Submission }, { params, auth, queryOptions }) =>
     Form.getByXmlFormId(params.formId)

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -51,9 +51,8 @@ should.Assertion.add('User', function() {
 });
 
 const assertSubmissionBase = (obj) => {
-  Object.keys(obj).should.containDeep([ 'instanceId', 'xml', 'createdAt', 'updatedAt', 'submitter' ]);
+  Object.keys(obj).should.containDeep([ 'instanceId', 'createdAt', 'updatedAt', 'submitter' ]);
   obj.instanceId.should.be.a.String();
-  obj.xml.should.be.a.String();
   obj.createdAt.should.be.an.isoDate();
   if (obj.updatedAt != null) obj.updatedAt.should.be.an.isoDate();
 };
@@ -70,6 +69,7 @@ should.Assertion.add('ExtendedSubmission', function() {
 
   assertSubmissionBase(this.obj);
   this.obj.submitter.should.be.an.Actor();
+  this.obj.xml.should.be.a.String();
 });
 
 should.Assertion.add('Session', function() {
@@ -101,9 +101,8 @@ should.Assertion.add('ExtendedFieldKey', function() {
 should.Assertion.add('Form', function() {
   this.params = { operator: 'to be a Form' };
 
-  Object.keys(this.obj).should.containDeep([ 'xmlFormId', 'xml', 'createdAt', 'updatedAt', 'name', 'version', 'hash' ]);
+  Object.keys(this.obj).should.containDeep([ 'xmlFormId', 'createdAt', 'updatedAt', 'name', 'version', 'hash' ]);
   this.obj.xmlFormId.should.be.a.String();
-  this.obj.xml.should.be.a.String();
   this.obj.createdAt.should.be.an.isoDate();
   if (this.obj.updatedAt != null) this.obj.updatedAt.should.be.an.isoDate();
   if (this.obj.name != null) this.obj.name.should.be.a.String();
@@ -115,7 +114,8 @@ should.Assertion.add('ExtendedForm', function() {
   this.params = { operator: 'to be a ExtendedForm' };
 
   this.obj.should.be.a.Form();
-  Object.keys(this.obj).should.containDeep([ 'submissions', 'lastSubmission' ]);
+  Object.keys(this.obj).should.containDeep([ 'xml', 'submissions', 'lastSubmission' ]);
+  this.obj.xml.should.be.a.String();
   if (this.obj.submissions != null) this.obj.submissions.should.be.a.Number();
   if (this.obj.lastSubmission != null) this.obj.lastSubmission.should.be.an.isoDate();
 });

--- a/test/integration/api/forms.js
+++ b/test/integration/api/forms.js
@@ -35,6 +35,7 @@ describe('api: /forms', () => {
               const simple = body.find((form) => form.xmlFormId === 'simple');
               simple.submissions.should.equal(1);
               simple.lastSubmission.should.be.a.recentIsoDate();
+              simple.xml.should.startWith('<');
             })))));
   });
 
@@ -230,6 +231,7 @@ describe('api: /forms', () => {
     it('should return just xml', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.get('/v1/forms/simple')
+          .set('X-Extended-Metadata', 'true')
           .expect(200)
           .then((full) => 
             asAlice.get('/v1/forms/simple.xml')
@@ -349,6 +351,7 @@ describe('api: /forms', () => {
               body.submissions.should.equal(0);
               body.createdBy.should.be.an.Actor();
               body.createdBy.displayName.should.equal('Alice');
+              body.xml.should.equal(testData.forms.simple2);
             })))));
   });
 
@@ -370,7 +373,6 @@ describe('api: /forms', () => {
               body.should.be.a.Form();
               body.name.should.equal('a fancy name');
               body.state.should.equal('draft');
-              body.xml.should.equal(testData.forms.simple);
             })))));
 
     it('should reject if state is invalid', testService((service) =>
@@ -385,6 +387,7 @@ describe('api: /forms', () => {
           .send({ xmlFormId: 'changed', xml: 'changed', hash: 'changed' })
           .expect(200)
           .then(() => asAlice.get('/v1/forms/simple')
+            .set('X-Extended-Metadata', 'true')
             .expect(200)
             .then(({ body }) => {
               body.xmlFormId.should.equal('simple');

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -354,6 +354,21 @@ describe('api: /forms/:id/submissions', () => {
             })))));
   });
 
+  describe('/:instanceId.xml GET', () => {
+    it('should return submission details', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/forms/simple/submissions')
+          .send(testData.instances.simple.one)
+          .set('Content-Type', 'text/xml')
+          .expect(200)
+          .then(() => asAlice.get('/v1/forms/simple/submissions/one.xml')
+            .expect(200)
+            .then(({ header, text }) => {
+              header['content-type'].should.equal('application/xml; charset=utf-8');
+              text.should.equal(testData.instances.simple.one);
+            })))));
+  });
+
   describe('/:instanceId GET', () => {
     it('should return notfound if the form does not exist', testService((service) =>
       service.login('alice', (asAlice) =>

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -73,6 +73,7 @@ describe('api: /submission', () => {
             text.should.match(/upload was successful/);
           })
           .then(() => asAlice.get('/v1/forms/simple/submissions/one')
+            .set('X-Extended-Metadata', 'true')
             .expect(200)
             .then(({ body }) => {
               body.createdAt.should.be.a.recentIsoDate();
@@ -349,6 +350,7 @@ describe('api: /forms/:id/submissions', () => {
               body.length.should.equal(1);
               body[0].should.be.an.ExtendedSubmission();
               body[0].submitter.displayName.should.equal('Alice');
+              body[0].xml.should.equal('<data id="simple"><meta><instanceID>one</instanceID></meta><name>Alice</name><age>30</age></data>');
             })))));
   });
 
@@ -395,6 +397,7 @@ describe('api: /forms/:id/submissions', () => {
             .then(({ body }) => {
               body.should.be.an.ExtendedSubmission();
               body.submitter.displayName.should.equal('Alice');
+              body.xml.should.equal(testData.instances.simple.one);
             })))));
   });
 


### PR DESCRIPTION
* this applies to list as well as individual fetch (GET / and GET /:id).
* picked up a bug where Extended Submissions were only accidentally
  working; now they actual work.
* resolves #103.