### PR TITLE
bug: need to commit before formulating endpoint response.

### DIFF
--- a/lib/http/endpoint.js
+++ b/lib/http/endpoint.js
@@ -121,17 +121,19 @@ const endpointBase = ({ preprocessor = noop, before = noop, resultWriter, errorW
 
       // and now run our actual resource handler with the given container and context:
       .then((context) => resource(localContainer, context, request, response))
-      .then((result) => finalize(result, request, response))
+      .then((result) => finalize(result, request, response)))
 
-      // assuming all goes well, run our result writer to actually write an output.
-      .then((result) => { resultWriter(result, request, response); }))
+  // n.b. the following happen /outside/ the transaction injection! this is so we
+  // don't respond before commit, and can catch without preventing the transaction
+  // rollback.
+
+  // assuming all goes well, run our result writer to actually write an output.
+    .then((result) => { resultWriter(result, request, response); })
 
   // and if not, run our error handler to write the error. if it is an internal
   // error we rethrow it so that the sentry handler in the standard node error
   // infrastructure picks it up for output.
   //
-  // n.b. this happens /outside/ the transaction injection! this is so we can
-  // catch without preventing the transaction rollback.
     .catch((err) => {
       if ((err != null) && ((err.isProblem !== true) || (err.httpCode === 500)))
         next(err);

--- a/test/unit/http/endpoint.js
+++ b/test/unit/http/endpoint.js
@@ -367,7 +367,8 @@ describe('endpoints', () => {
         } };
 
         return endpointBase({
-          before() { throw Problem.user.notFound(); }
+          before() { throw Problem.user.notFound(); },
+          resultWriter() {}
         })(container)(always(true))({ method: 'POST' })
           .then(() => { transacted.should.equal(true); });
       });
@@ -380,21 +381,9 @@ describe('endpoints', () => {
           return cb().should.be.rejectedWith(Problem, { problemCode: 404.1 });
         } };
 
-        return endpointBase({})(container)(() => { throw Problem.user.notFound(); })({ method: 'POST' })
-          .then(() => { transacted.should.equal(true); });
-      });
-
-      it('should reject on the transacting promise on resultWriter failure', () => {
-        // we still check the transacted flag just to be sure the rejectedWith assertion runs.
-        let transacted = false;
-        const container = { transacting(cb) {
-          transacted = true;
-          return cb().should.be.rejectedWith(Problem, { problemCode: 404.1 });
-        } };
-
         return endpointBase({
-          resultWriter() { throw Problem.user.notFound(); }
-        })(container)(always(true))({ method: 'POST' })
+          resultWriter() {}
+        })(container)(() => { throw Problem.user.notFound(); })({ method: 'POST' })
           .then(() => { transacted.should.equal(true); });
       });
     });


### PR DESCRIPTION
* otherwise back-to-back requests may not have the intended effect.
* eg, logging in then immediately using the new session token.
* this change means that response formulation no longer occurs within
  transaction context, which means we might commit things then fail to
  tell the user.
  * but i guess this is how most services work.