### PR TITLE
improve #156: change .csv.zip export dir structure to match briefcase.

### DIFF
--- a/lib/data/attachments.js
+++ b/lib/data/attachments.js
@@ -22,7 +22,7 @@ const streamAttachments = (inStream) => {
   // luckily, this is not actually illegal in the zip spec; two files can live at precisely
   // the same location, and the conflict is dealt with interactively by the unzipping client.
   inStream.on('data', ({ instanceId, name, content }) =>
-    archive.append(content, { name: join('files', sanitize(instanceId), sanitize(name)) }));
+    archive.append(content, { name: join('media', sanitize(name)) }));
   inStream.on('end', () => archive.finalize());
 
   return archive;

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -284,20 +284,20 @@ describe('api: /forms/:id/submissions', () => {
           .then(() => asAlice.post('/v1/submission')
             .set('X-OpenRosa-Version', '1.0')
             .attach('xml_submission_file', Buffer.from(testData.instances.simple.two), { filename: 'data.xml' })
-            .attach('file1.txt', Buffer.from('this is test file three'), { filename: 'file1.txt' })
+            .attach('file3.txt', Buffer.from('this is test file three'), { filename: 'file3.txt' })
             .expect(201))
           .then(() => new Promise((done) =>
             zipStreamToFiles(asAlice.get('/v1/forms/simple/submissions.csv.zip'), (result) => {
               result.filenames.should.containDeep([
                 'simple.csv',
-                'files/one/file1.txt',
-                'files/one/file2.txt',
-                'files/two/file1.txt'
+                'media/file1.txt',
+                'media/file2.txt',
+                'media/file3.txt'
               ]);
 
-              result['files/one/file1.txt'].should.equal('this is test file one');
-              result['files/one/file2.txt'].should.equal('this is test file two');
-              result['files/two/file1.txt'].should.equal('this is test file three');
+              result['media/file1.txt'].should.equal('this is test file one');
+              result['media/file2.txt'].should.equal('this is test file two');
+              result['media/file3.txt'].should.equal('this is test file three');
 
               done();
             }))))));

--- a/test/unit/data/attachments.js
+++ b/test/unit/data/attachments.js
@@ -10,18 +10,18 @@ describe('.zip attachments streaming', () => {
     const inStream = streamTest.fromObjects([
       { instanceId: 'subone', name: 'firstfile.ext', content: 'this is my first file' },
       { instanceId: 'subone', name: 'secondfile.ext', content: 'this is my second file' },
-      { instanceId: 'subtwo', name: 'firstfile.ext', content: 'this is my other first file' }
+      { instanceId: 'subtwo', name: 'thirdfile.ext', content: 'this is my third file' }
     ]);
     zipStreamToFiles(zipStreamFromParts(streamAttachments(inStream)), (result) => {
       result.filenames.should.eql([
-        'files/subone/firstfile.ext', 
-        'files/subone/secondfile.ext', 
-        'files/subtwo/firstfile.ext'
+        'media/firstfile.ext', 
+        'media/secondfile.ext', 
+        'media/thirdfile.ext'
       ]);
 
-      result['files/subone/firstfile.ext'].should.equal('this is my first file');
-      result['files/subone/secondfile.ext'].should.equal('this is my second file');
-      result['files/subtwo/firstfile.ext'].should.equal('this is my other first file');
+      result['media/firstfile.ext'].should.equal('this is my first file');
+      result['media/secondfile.ext'].should.equal('this is my second file');
+      result['media/thirdfile.ext'].should.equal('this is my third file');
 
       done();
     });
@@ -35,9 +35,9 @@ describe('.zip attachments streaming', () => {
     ]);
     zipStreamToFiles(zipStreamFromParts(streamAttachments(inStream)), (result) => {
       result.filenames.should.eql([
-        'files/..subone/firstfile.ext',
-        'files/subone/..secondfile.ext',
-        'files/subone/..secondfile.ext'
+        'media/firstfile.ext',
+        'media/..secondfile.ext',
+        'media/..secondfile.ext'
       ]);
 
       done();


### PR DESCRIPTION
* "media", not "files".
* do not create subfolders per instance.
* resolves #156.