### PR TITLE
add RESTful attachment to submissions subresource

### DIFF
--- a/lib/data/attachments.js
+++ b/lib/data/attachments.js
@@ -7,7 +7,7 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 //
-// Given the Postgres rowstream returned by submissions.streamAttachmentsByFormId,
+// Given the Postgres rowstream returned by SubmissionAttachment.streamByFormId,
 // here we use the util/zip multifile zipstreamer to archive all attachments into
 // the archive.
 

--- a/lib/data/attachments.js
+++ b/lib/data/attachments.js
@@ -21,7 +21,7 @@ const streamAttachments = (inStream) => {
   // this sanitization means that two filenames could end up identical.
   // luckily, this is not actually illegal in the zip spec; two files can live at precisely
   // the same location, and the conflict is dealt with interactively by the unzipping client.
-  inStream.on('data', ({ instanceId, name, content }) =>
+  inStream.on('data', ({ name, content }) =>
     archive.append(content, { name: join('media', sanitize(name)) }));
   inStream.on('end', () => archive.finalize());
 

--- a/lib/data/submission.js
+++ b/lib/data/submission.js
@@ -1,0 +1,71 @@
+// Copyright 2018 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const { Readable } = require('stream');
+const hparser = require('htmlparser2');
+const { last } = require('ramda');
+const ptr = last; // just an alias.
+const { schemaAsLookup, stripNamespacesFromSchema } = require('./schema');
+const { stripNamespacesFromPath } = require('../util/xml');
+const { noop } = require('../util/util');
+
+// reads submission xml with the streaming parser, and outputs a stream of every
+// field in the submission. does no processing at all to localize repeat groups,
+// etc. it's just a stream of found data values.
+const submissionToFieldStream = (submission, form) => form.schema().then((schema) => {
+  const lookup = schemaAsLookup(stripNamespacesFromSchema(schema));
+  const outStream = new Readable({ objectMode: true, read: noop });
+
+  const fieldStack = [{ children: lookup }];
+  let droppedWrapper = false;
+  let textBuffer = ''; // agglomerates text nodes that come as multiple events.
+  const parser = new hparser.Parser({
+    onopentag: (fullname) => {
+      // drop the root xml tag.
+      if (droppedWrapper === false) {
+        droppedWrapper = true;
+        return;
+      }
+
+      const name = stripNamespacesFromPath(fullname);
+      const fieldPtr = ptr(fieldStack);
+      if ((fieldPtr != null) && (fieldPtr.children[name] != null)) {
+        // we have a schema definition for this field. update state as appropriate.
+        const field = fieldPtr.children[name];
+        fieldStack.push(field);
+        textBuffer = '';
+      } else {
+        fieldStack.push(null);
+      }
+    },
+    ontext: (text) => {
+      textBuffer += text;
+    },
+    onclosetag: () => {
+      const field = fieldStack.pop();
+
+      if (textBuffer !== '') {
+        if (field.children == null) // don't output useless whitespace
+          outStream.push({ field, text: textBuffer });
+        textBuffer = '';
+      }
+
+      if (fieldStack.length === 0) {
+        parser.reset();
+        outStream.push(null);
+      }
+    }
+  }, { xmlMode: true, decodeEntities: true });
+  parser.write(submission.xml);
+
+  return outStream;
+});
+
+module.exports = { submissionToFieldStream };
+

--- a/lib/model/instance/submission-attachment.js
+++ b/lib/model/instance/submission-attachment.js
@@ -16,8 +16,10 @@ const Instance = require('./instance');
 
 module.exports = Instance('submission_attachments', {
   all: [ 'submissionId', 'blobId', 'name' ]
-})(({ SubmissionAttachment, simply }) => class {
+})(({ SubmissionAttachment, simply, submissions }) => class {
   forApi() { return this.name; }
+
+  delete() { submissions.deleteAttachment(this); }
 
   static getBySubmission(submissionId, name) {
     return simply.getOneWhere('submission_attachments', { submissionId, name }, SubmissionAttachment);

--- a/lib/model/instance/submission-attachment.js
+++ b/lib/model/instance/submission-attachment.js
@@ -16,13 +16,14 @@ const Instance = require('./instance');
 
 module.exports = Instance('submission_attachments', {
   all: [ 'submissionId', 'blobId', 'name' ]
-})(({ SubmissionAttachment, simply, submissions }) => class {
-  forApi() { return this.name; }
+})(({ SubmissionAttachment, simply, submissionAttachments }) => class {
+  forApi() { return { name: this.name, exists: (this.blobId != null) }; }
 
-  delete() { submissions.deleteAttachment(this); }
+  clear() { submissionAttachments.update(this.with({ blobId: null })); }
 
-  static getBySubmission(submissionId, name) {
+  static getBySubmissionId(submissionId, name) {
     return simply.getOneWhere('submission_attachments', { submissionId, name }, SubmissionAttachment);
   }
+  static streamByFormId(formId) { return submissionAttachments.streamByFormId(formId); }
 });
 

--- a/lib/model/instance/submission.js
+++ b/lib/model/instance/submission.js
@@ -26,7 +26,7 @@ const { submissionToFieldStream } = require('../../data/submission');
 const Problem = require('../../util/problem');
 const { withCreateTime } = require('../../util/instance');
 const Option = require('../../util/option');
-const { blankStringToNull, superproto } = require('../../util/util');
+const { isBlank, blankStringToNull, superproto } = require('../../util/util');
 const { resolve } = require('../../util/promise');
 const { consumeAndBuffer, mapStreamToPromises } = require('../../util/stream');
 const { traverseXml, findOne, root, node, attr, text } = require('../../util/xml');
@@ -87,8 +87,10 @@ out.Submission = Instance.with(HasExtended(ExtendedSubmission))('submissions', {
   createExpectedAttachments(form, files = []) {
     return submissionToFieldStream(this, form)
       .then((stream) => mapStreamToPromises(({ field, text: nameText }) => {
-        const expectedName = nameText.trim();
         if ((field.type !== 'binary') && (field.type !== 'audit')) return Option.none();
+
+        const expectedName = nameText.trim();
+        if (isBlank(expectedName)) return Option.none(); // ensure it's not just an empty tag
 
         const file = files.find((x) => x.fieldname === expectedName);
         const makeBlobId = (file == null)
@@ -126,7 +128,7 @@ out.Submission = Instance.with(HasExtended(ExtendedSubmission))('submissions', {
   }
 
   getAttachmentMetadata() {
-    return simply.getWhere('submission_attachments', { submissionId: this.id }, SubmissionAttachment);
+    return submissionAttachments.getAllBySubmissionId(this.id);
   }
 
   // Because the XML alone does not include information on the internal sequential

--- a/lib/model/instance/submission.js
+++ b/lib/model/instance/submission.js
@@ -58,15 +58,13 @@ const ExtendedSubmission = ExtendedInstance({
 out.Submission = Instance.with(HasExtended(ExtendedSubmission))('submissions', {
   all: [ 'id', 'formId', 'instanceId', 'xml', 'submitter', 'createdAt', 'updatedAt', 'deletedAt' ],
   readable: [ 'instanceId', 'submitter', 'createdAt', 'updatedAt' ]
-})(({ PartialSubmission, SubmissionAttachment, Blob, simply, submissions }) => class {
+})(({ PartialSubmission, SubmissionAttachment, simply, submissions }) => class {
 
   forCreate() { return withCreateTime(this); }
   create() { return simply.create('submissions', this); }
 
-  attach(name, contentType, path) {
-    return Blob.fromFile(path, contentType)
-      .then((blob) => blob.create())
-      .then((savedBlob) => submissions.createAttachment(new SubmissionAttachment({ submissionId: this.id, blobId: savedBlob.id, name })));
+  attach(name, blob) {
+    return submissions.createAttachment(new SubmissionAttachment({ submissionId: this.id, blobId: blob.id, name }));
   }
 
   getAttachmentMetadata() { return simply.getWhere('submission_attachments', { submissionId: this.id }, SubmissionAttachment); }

--- a/lib/model/instance/submission.js
+++ b/lib/model/instance/submission.js
@@ -20,19 +20,28 @@
 
 const { merge } = require('ramda');
 const uuid = require('uuid/v4');
-const { traverseXml, findOne, root, node, attr, text } = require('../../util/xml');
 const Instance = require('./instance');
 const { ExtendedInstance, HasExtended } = require('../trait/extended');
+const { submissionToFieldStream } = require('../../data/submission');
 const Problem = require('../../util/problem');
 const { withCreateTime } = require('../../util/instance');
 const Option = require('../../util/option');
 const { blankStringToNull, superproto } = require('../../util/util');
-const { consumeAndBuffer } = require('../../util/stream');
+const { resolve } = require('../../util/promise');
+const { consumeAndBuffer, mapStreamToPromises } = require('../../util/stream');
+const { traverseXml, findOne, root, node, attr, text } = require('../../util/xml');
 
 
 // Attach the two classes to an object rather than declaring named vars so the
 // linter doesn't trip.
 const out = {};
+
+
+////////////////////////////////////////////////////////////////////////////////
+// PARTIAL SUBMISSION
+// this is a partially complete submission instance (mostly, it's missing form
+// parent information) which understands how to compelete itself. it's returned
+// by Submission.fromXml.
 
 // TODO/CR: should this be in its own file for consistency?
 out.PartialSubmission = Instance()(({ Submission }) => class {
@@ -46,6 +55,11 @@ out.PartialSubmission = Instance()(({ Submission }) => class {
   }
 });
 
+
+////////////////////////////////////////////////////////////////////////////////
+// EXTENDED SUBMISSION
+// output format.
+
 /* eslint-disable */ // because its newline requirements here are insane.
 const ExtendedSubmission = ExtendedInstance({
   fields: {
@@ -55,19 +69,65 @@ const ExtendedSubmission = ExtendedInstance({
 });
 /* eslint-enable */
 
+
+////////////////////////////////////////////////////////////////////////////////
+// SUBMISSION
+
 out.Submission = Instance.with(HasExtended(ExtendedSubmission))('submissions', {
   all: [ 'id', 'formId', 'instanceId', 'xml', 'submitter', 'createdAt', 'updatedAt', 'deletedAt' ],
   readable: [ 'instanceId', 'submitter', 'createdAt', 'updatedAt' ]
-})(({ PartialSubmission, SubmissionAttachment, simply, submissions }) => class {
+})(({ Blob, PartialSubmission, SubmissionAttachment, simply, submissions, submissionAttachments }) => class {
 
   forCreate() { return withCreateTime(this); }
   create() { return simply.create('submissions', this); }
 
-  attach(name, blob) {
-    return submissions.createAttachment(new SubmissionAttachment({ submissionId: this.id, blobId: blob.id, name }));
+  // given the submission xml, creates the expected attachments as rows in the
+  // database. if a files array is given (via multipart.any()) and the expected
+  // file is present, it will be attached automatically.
+  createExpectedAttachments(form, files = []) {
+    return submissionToFieldStream(this, form)
+      .then((stream) => mapStreamToPromises(({ field, text: nameText }) => {
+        const expectedName = nameText.trim();
+        if ((field.type !== 'binary') && (field.type !== 'audit')) return Option.none();
+
+        const file = files.find((x) => x.fieldname === expectedName);
+        const makeBlobId = (file == null)
+          ? resolve(null)
+          : Blob.fromFile(file.path, file.mimetype)
+            .then((blob) => blob.create())
+            .then((savedBlob) => savedBlob.id);
+
+        return Option.of(makeBlobId.then((blobId) => submissionAttachments
+          .create(new SubmissionAttachment({ submissionId: this.id, blobId, name: expectedName }))));
+      }, stream));
   }
 
-  getAttachmentMetadata() { return simply.getWhere('submission_attachments', { submissionId: this.id }, SubmissionAttachment); }
+  // given a submission whose expected attachment records have already been created,
+  // and a files array (via multipart.any()), updates all matching attachments with
+  // the new binary data.
+  addAttachments(files) {
+    return this.getAttachmentMetadata()
+      .then((expecteds) => Promise.all(files
+        .filter((file) => expecteds.some((expected) => file.fieldname === expected.name))
+        .map((file) => Blob.fromFile(file.path, file.mimetype)
+          .then((blob) => blob.create())
+          .then((blob) => submissionAttachments
+            .update(new SubmissionAttachment({
+              submissionId: this.id, blobId: blob.id, name: file.fieldname
+            }))))));
+  }
+
+  // attempts to attach a single blob to this submission, by association with its
+  // file name.
+  attach(name, blob) {
+    return submissionAttachments.update(new SubmissionAttachment({
+      submissionId: this.id, blobId: blob.id, name
+    }));
+  }
+
+  getAttachmentMetadata() {
+    return simply.getWhere('submission_attachments', { submissionId: this.id }, SubmissionAttachment);
+  }
 
   // Because the XML alone does not include information on the internal sequential
   // integer ID of the Form it is related to or the Actor that is creating it, this
@@ -100,9 +160,7 @@ out.Submission = Instance.with(HasExtended(ExtendedSubmission))('submissions', {
   static getById(formId, instanceId, options) { return submissions.getById(formId, instanceId, options); }
   static getAllByFormId(formId, options) { return submissions.getAllByFormId(formId, options); }
   static countByFormId(formId) { return simply.countWhere('submissions', { formId }); }
-
-  static streamRowsByFormId(formId, options) { return submissions.streamRowsByFormId(formId, options); }
-  static streamAttachmentsByFormId(formId) { return submissions.streamAttachmentsByFormId(formId); }
+  static streamByFormId(formId, options) { return submissions.streamByFormId(formId, options); }
 });
 
 module.exports = out;

--- a/lib/model/migrations/20181219-01-add-submission-update-verb.js
+++ b/lib/model/migrations/20181219-01-add-submission-update-verb.js
@@ -1,0 +1,19 @@
+// Copyright 2018 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = (db) =>
+  db.select('id').from('roles').where({ system: 'admin' })
+    .then(([{ id }]) => db.insert({ roleId: id, verb: 'submission.update' }).into('grants'));
+
+const down = (db) =>
+  db.select('id').from('roles').where({ system: 'admin' })
+    .then(([{ id }]) => db.delete().from('grants').where({ roleId: id, verb: 'submission.update' }))
+
+module.exports = { up, down };
+

--- a/lib/model/migrations/20181221-01-nullable-submission-blobs.js
+++ b/lib/model/migrations/20181221-01-nullable-submission-blobs.js
@@ -7,13 +7,13 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const up = (db) =>
-  db.select('id').from('roles').where({ system: 'admin' })
-    .then(([{ id }]) => db.insert({ roleId: id, verb: 'submission.update' }).into('grants'));
+const up = (db) => db.schema.table('submission_attachments', (sa) => {
+  sa.integer('blobId').nullable().alter();
+});
 
-const down = (db) =>
-  db.select('id').from('roles').where({ system: 'admin' })
-    .then(([{ id }]) => db.delete().from('grants').where({ roleId: id, verb: 'submission.update' }));
+const down = (db) => db.schema.table('submission_attachments', (sa) => {
+  sa.integer('blobId').notNullable().alter();
+});
 
 module.exports = { up, down };
 

--- a/lib/model/package.js
+++ b/lib/model/package.js
@@ -78,6 +78,7 @@ injector.withDefaults = (base, { queries, instances } = {}) => {
     roles: require('./query/roles'),
     sessions: require('./query/sessions'),
     submissions: require('./query/submissions'),
+    submissionAttachments: require('./query/submission-attachments'),
     simply: require('./query/simply'),
     users: require('./query/users')
   };

--- a/lib/model/query/submission-attachments.js
+++ b/lib/model/query/submission-attachments.js
@@ -1,0 +1,46 @@
+// Copyright 2018 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+//
+// Submission Attachments are files that are expected to exist given the submission
+// xml data and the form XForms xml definition.
+
+const Problem = require('../../util/problem');
+const { wasUpdateSuccessful, translateProblem } = require('../../util/db');
+
+module.exports = {
+  // The attachment will already contain information about its relationship to this
+  // Submission, as it is a join entity.
+  create: (attachment) => ({ simply }) =>
+    simply.create('submission_attachments', attachment)
+      // TODO: i think maybe this isn't necessary anymore?
+      .catch(translateProblem(
+        ((problem) => problem.code === Problem.user.uniquenessViolation({}).code), // TODO: easier comparison
+        ((problem) => Problem.user.uniquenessViolation({ fields: [ '(attachment file names)' ], values: [ problem.problemDetails.values[1] ] }))
+      )),
+
+  // we have to implement our own update here since submission attachments have no
+  // int id primary key; it's just a join table.
+  // here we don't do .returning('*') and give back the new record since it's a
+  // big binary blob we'd rather not ship around all over.
+  update: (sa) => ({ db }) =>
+    db.update({ blobId: sa.blobId }).into('submission_attachments')
+      .where({ submissionId: sa.submissionId, name: sa.name })
+      .then(wasUpdateSuccessful),
+
+  // Returns a hybrid set of information from the Attachments and Blobs tables.
+  streamByFormId: (formId) => ({ db }) =>
+    db
+      .select('submissions.instanceId', 'submission_attachments.name', 'blobs.content', 'blobs.contentType')
+      .from('submissions')
+      .where({ formId })
+      .join('submission_attachments', 'submission_attachments.submissionId', 'submissions.id')
+      .join('blobs', 'blobs.id', 'submission_attachments.blobId')
+      .stream()
+};
+

--- a/lib/model/query/submission-attachments.js
+++ b/lib/model/query/submission-attachments.js
@@ -11,9 +11,17 @@
 // xml data and the form XForms xml definition.
 
 const Problem = require('../../util/problem');
-const { wasUpdateSuccessful, translateProblem } = require('../../util/db');
+const { wasUpdateSuccessful, rowsToInstances, translateProblem } = require('../../util/db');
 
 module.exports = {
+  // we want to enforce a consistent ordering so we don't use simply.
+  getAllBySubmissionId: (submissionId) => ({ db, SubmissionAttachment }) =>
+    db.select('*')
+      .from('submission_attachments')
+      .where({ submissionId })
+      .orderBy('name')
+      .then(rowsToInstances(SubmissionAttachment)),
+
   // The attachment will already contain information about its relationship to this
   // Submission, as it is a join entity.
   create: (attachment) => ({ simply }) =>

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -7,9 +7,8 @@
 // including this file, may be copied, modified, propagated, or distributed
 // except according to the terms contained in the LICENSE file.
 
-const Problem = require('../../util/problem');
 const { map } = require('ramda');
-const { fieldsForJoin, joinRowToInstance, maybeFirst, translateProblem, QueryOptions, applyPagingOptions } = require('../../util/db');
+const { fieldsForJoin, joinRowToInstance, maybeFirst, QueryOptions, applyPagingOptions } = require('../../util/db');
 const { mapStream } = require('../../util/stream');
 
 
@@ -20,32 +19,9 @@ module.exports = {
   getAllByFormId: (formId, options = QueryOptions.none) => ({ submissions }) =>
     submissions._get(options.withCondition({ formId })),
 
-  streamRowsByFormId: (formId, options = QueryOptions.none) => ({ submissions }) =>
+  streamByFormId: (formId, options = QueryOptions.none) => ({ submissions }) =>
     submissions.helper.base(options.withCondition({ formId }))
       .pipe(mapStream(submissions.helper.deserializer(options.extended))),
-
-  // The attachment will already contain information about its relationship to this
-  // Submission, as it is a join entity.
-  createAttachment: (attachment) => ({ simply }) =>
-    simply.create('submission_attachments', attachment)
-      .catch(translateProblem(
-        ((problem) => problem.code === Problem.user.uniquenessViolation({}).code), // TODO: easier comparison
-        ((problem) => Problem.user.uniquenessViolation({ fields: [ '(attachment file names)' ], values: [ problem.problemDetails.values[1] ] }))
-      )),
-
-  // Returns a hybrid set of information from the Attachments and Blobs tables.
-  streamAttachmentsByFormId: (formId) => ({ db }) =>
-    db
-      .select('submissions.instanceId', 'submission_attachments.name', 'blobs.content', 'blobs.contentType')
-      .from('submissions')
-      .where({ formId })
-      .join('submission_attachments', 'submission_attachments.submissionId', 'submissions.id')
-      .join('blobs', 'blobs.id', 'submission_attachments.blobId')
-      .stream(),
-
-  deleteAttachment: (attachment) => ({ db }) =>
-    db.delete().from('submission_attachments')
-      .where({ submissionId: attachment.submissionId, name: attachment.name }),
 
   _get: (options) => ({ submissions }) =>
     submissions.helper.base(options)

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -43,6 +43,10 @@ module.exports = {
       .join('blobs', 'blobs.id', 'submission_attachments.blobId')
       .stream(),
 
+  deleteAttachment: (attachment) => ({ db }) =>
+    db.delete().from('submission_attachments')
+      .where({ submissionId: attachment.submissionId, name: attachment.name }),
+
   _get: (options) => ({ submissions }) =>
     submissions.helper.base(options)
       .then(map(submissions.helper.deserializer(options.extended))),

--- a/lib/resources/odata.js
+++ b/lib/resources/odata.js
@@ -56,7 +56,7 @@ module.exports = (service, endpoint) => {
         .then((form) => {
           const options = QueryOptions.fromODataRequest(params, query);
           return Promise.all([
-            Submission.streamRowsByFormId(form.id, options),
+            Submission.streamByFormId(form.id, options),
             ((params.table === 'Submissions') && options.hasPaging())
               ? Submission.countByFormId(form.id) : resolve(null)
           ])

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -11,7 +11,7 @@ const { createReadStream } = require('fs');
 const { always } = require('ramda');
 const sanitize = require('sanitize-filename');
 const { createdMessage } = require('../outbound/openrosa');
-const { getOrNotFound, getOrReject, rejectIf, reject } = require('../util/promise');
+const { getOrNotFound, getOrReject, rejectIf, reject, resolve, ignoringResult } = require('../util/promise');
 const { success, xml } = require('../util/http');
 const Option = require('../util/option');
 const Problem = require('../util/problem');
@@ -25,6 +25,10 @@ const tmpdir = require('tmp').dirSync();
 const multipart = multer({ dest: tmpdir.name });
 
 module.exports = (service, endpoint) => {
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // SUBMISSIONS (OPENROSA)
+
   // Nonstandard REST; OpenRosa-specific API.
   // This bit of silliness is to address the fact that the OpenRosa standards
   // specification requires the presence of a HEAD /submission endpoint, but
@@ -44,7 +48,7 @@ module.exports = (service, endpoint) => {
       })));
 
   // Nonstandard REST; OpenRosa-specific API.
-  service.post('/projects/:projectId/submission', multipart.any(), endpoint.openRosa(({ Audit, Blob, Project, Submission }, { params, files, auth }) =>
+  service.post('/projects/:projectId/submission', multipart.any(), endpoint.openRosa(({ Audit, Project, Submission }, { params, files, auth }) =>
     // first, make sure the project exists, and that we have the right to submit to it.
     Project.getById(params.projectId)
       .then(getOrNotFound)
@@ -60,27 +64,27 @@ module.exports = (service, endpoint) => {
             (form) => !form.acceptsSubmissions(),
             always(Problem.user.notAcceptingSubmissions())
           ))
-          // now we must check for an extant submission by this id, to handle additional
-          // posted files.
-          // * if an submission exists, we reject unless the xml matches.
-          // * if it does not, we create it.
-          // either way, we exit this branching promise path with a Promise[Submission]
-          // that is complete (eg with an id).
           .then((form) => Submission.getById(form.id, partial.instanceId)
+            // we branch based on whether a submission already existed; in either case, we exit this
+            // branching promise path with a Promise[Submission] that is complete (eg with an id).
             .then((maybeExtant) => maybeExtant
+              // if a submission already exists, first verify that the posted xml still matches
+              // (if it does not, reject). then, attach any new posted files.
               .map((extant) => ((Buffer.compare(Buffer.from(extant.xml), Buffer.from(partial.xml)) !== 0)
                 ? reject(Problem.user.xmlConflict())
-                : extant))
-              .orElseGet(() => partial.complete(form, auth.actor()).create()))
-            // now we have a definite submission. we need to go through remaining fields
-            // and attempt to add them all as files.
-            .then((submission) => Promise.all(files
-              .filter((file) => file.fieldname !== 'xml_submission_file')
-              .map((file) => Blob.fromFile(file.path, file.mimetype)
-                .then((blob) => blob.create())
-                .then((savedBlob) => submission.attach(file.fieldname, savedBlob))))
-              .then(() => Audit.log(auth.actor(), 'submission.create', form, { submissionId: submission.id }))
-              .then(always(createdMessage({ message: 'full submission upload was successful!' })))))))));
+                : resolve(extant).then(ignoringResult((submission) => submission.addAttachments(files)))))
+              // otherwise, this is the first POST for this submission. create the
+              // submission and the expected attachments:
+              .orElseGet(() => partial.complete(form, auth.actor()).create()
+                .then(ignoringResult((submission) => submission.createExpectedAttachments(form, files)))))
+            // now we have a definite submission; we just need to do audit logging.
+            .then((submission) => Audit.log(auth.actor(), 'submission.create', form, { submissionId: submission.id }))
+            // TODO: perhaps actually decide between "full" and "partial"; aggregate does this.
+            .then(always(createdMessage({ message: 'full submission upload was successful!' }))))))));
+
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // SUBMISSIONS (STANDARD REST)
 
   // The remaining endpoints follow a more-standard REST subresource route pattern.
   // This first one performs the operation as the above.
@@ -100,18 +104,19 @@ module.exports = (service, endpoint) => {
             always(Problem.user.notAcceptingSubmissions())
           ))
           .then((partial) => partial.complete(form, auth.actor()).create())
-          .then((submission) => Audit.log(auth.actor(), 'submission.create', form, { submissionId: submission.id })
+          .then((submission) => submission.createExpectedAttachments(form)
+            .then(() => Audit.log(auth.actor(), 'submission.create', form, { submissionId: submission.id }))
             .then(always(submission)))))));
 
-  service.get('/projects/:projectId/forms/:id/submissions.csv.zip', endpoint(({ all, Project, Submission }, { params, auth }, _, response) =>
+  service.get('/projects/:projectId/forms/:id/submissions.csv.zip', endpoint(({ all, Project, Submission, SubmissionAttachment }, { params, auth }, _, response) =>
     Project.getById(params.projectId)
       .then(getOrNotFound)
       .then((project) => auth.canOrReject('submission.read', project)
         .then(() => project.getFormByXmlFormId(params.id))
         .then(getOrNotFound)
         .then((form) => all.do([
-          Submission.streamRowsByFormId(form.id),
-          Submission.streamAttachmentsByFormId(form.id)
+          Submission.streamByFormId(form.id),
+          SubmissionAttachment.streamByFormId(form.id)
         ]).then(([ rows, attachments ]) => {
           const filename = sanitize(form.xmlFormId);
           response.append('Content-Disposition', `attachment; filename="${filename}.zip"`);
@@ -147,6 +152,10 @@ module.exports = (service, endpoint) => {
         .then((form) => Submission.getById(form.id, params.instanceId, queryOptions))
         .then(getOrNotFound))));
 
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // SUBMISSION ATTACHMENTS
+
   service.get(
     '/projects/:projectId/forms/:formId/submissions/:instanceId/attachments',
     endpoint(({ Project, Submission }, { params, auth }) =>
@@ -171,7 +180,7 @@ module.exports = (service, endpoint) => {
           // TODO: can be more performant+compact via a custom join.
           .then((form) => Submission.getById(form.id, params.instanceId))
           .then(getOrNotFound)
-          .then((submission) => SubmissionAttachment.getBySubmission(submission.id, params.name))
+          .then((submission) => SubmissionAttachment.getBySubmissionId(submission.id, params.name))
           .then(getOrNotFound)
           .then((attachment) => Blob.getById(attachment.blobId)
             .then(getOrNotFound)
@@ -182,7 +191,6 @@ module.exports = (service, endpoint) => {
             }))))
   );
 
-  // TODO/CR: sanitize/verify name legality? somehow? under what criteria?
   service.post(
     '/projects/:projectId/forms/:formId/submissions/:instanceId/attachments/:name',
     endpoint(({ Blob, Project, Submission }, { params, headers, auth }, request) =>
@@ -199,12 +207,15 @@ module.exports = (service, endpoint) => {
       ])
         // TODO: audit-log creation? (but we don't do it when via openrosa..)
         .then(([ submission, blob ]) => submission.attach(params.name, blob))
-        .then(success))
+        .then((wasSuccessful) => (wasSuccessful
+          ? success()
+          // should only be a Resolve[False] if everything worked but there wasn't a row to update.
+          : reject(Problem.user.notFound()))))
   );
 
   service.delete(
     '/projects/:projectId/forms/:formId/submissions/:instanceId/attachments/:name',
-    endpoint(({ Audit, Project, Submission, SubmissionAttachment }, { params, headers, auth }, request) =>
+    endpoint(({ Audit, Project, Submission, SubmissionAttachment }, { params, auth }) =>
       Project.getById(params.projectId)
         .then(getOrNotFound)
         .then((project) => auth.canOrReject('submission.update', project)
@@ -213,11 +224,11 @@ module.exports = (service, endpoint) => {
           // TODO: as with above (copy+paste) can be more performant+compact via a custom join.
           .then((form) => Submission.getById(form.id, params.instanceId)
             .then(getOrNotFound)
-            .then((submission) => SubmissionAttachment.getBySubmission(submission.id, params.name))
+            .then((submission) => SubmissionAttachment.getBySubmissionId(submission.id, params.name))
             .then(getOrNotFound)
             .then((attachment) => Promise.all([
-              attachment.delete(),
-              Audit.log(auth.actor(), 'submission.attachment.delete', form, { name: attachment.name, blobId: attachment.blobId })
+              attachment.clear(),
+              Audit.log(auth.actor(), 'submission.attachment.clear', form, { name: attachment.name, blobId: attachment.blobId })
             ]))
             .then(success))))
   );

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -44,7 +44,7 @@ module.exports = (service, endpoint) => {
       })));
 
   // Nonstandard REST; OpenRosa-specific API.
-  service.post('/projects/:projectId/submission', multipart.any(), endpoint.openRosa(({ all, Audit, Project, Submission }, { params, files, auth }) =>
+  service.post('/projects/:projectId/submission', multipart.any(), endpoint.openRosa(({ Audit, Blob, Project, Submission }, { params, files, auth }) =>
     // first, make sure the project exists, and that we have the right to submit to it.
     Project.getById(params.projectId)
       .then(getOrNotFound)
@@ -74,11 +74,13 @@ module.exports = (service, endpoint) => {
               .orElseGet(() => partial.complete(form, auth.actor()).create()))
             // now we have a definite submission. we need to go through remaining fields
             // and attempt to add them all as files.
-            .then((submission) => all.do(files
+            .then((submission) => Promise.all(files
               .filter((file) => file.fieldname !== 'xml_submission_file')
-              .map((file) => submission.attach(file.fieldname, file.mimetype, file.path)))
-              .then(() => Audit.log(auth.actor(), 'submission.create', form, { submissionId: submission.id })))
-            .then(always(createdMessage({ message: 'full submission upload was successful!' }))))))));
+              .map((file) => Blob.fromFile(file.path, file.mimetype)
+                .then((blob) => blob.create())
+                .then((savedBlob) => submission.attach(file.fieldname, savedBlob))))
+              .then(() => Audit.log(auth.actor(), 'submission.create', form, { submissionId: submission.id }))
+              .then(always(createdMessage({ message: 'full submission upload was successful!' })))))))));
 
   // The remaining endpoints follow a more-standard REST subresource route pattern.
   // This first one performs the operation as the above.

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -12,7 +12,7 @@ const { always } = require('ramda');
 const sanitize = require('sanitize-filename');
 const { createdMessage } = require('../outbound/openrosa');
 const { getOrNotFound, getOrReject, rejectIf, reject } = require('../util/promise');
-const { xml } = require('../util/http');
+const { success, xml } = require('../util/http');
 const Option = require('../util/option');
 const Problem = require('../util/problem');
 const { streamBriefcaseCsvs } = require('../data/briefcase');
@@ -181,6 +181,45 @@ module.exports = (service, endpoint) => {
               return blob.content;
             }))))
   );
-};
 
+  // TODO/CR: sanitize/verify name legality? somehow? under what criteria?
+  service.post(
+    '/projects/:projectId/forms/:formId/submissions/:instanceId/attachments/:name',
+    endpoint(({ Blob, Project, Submission }, { params, headers, auth }, request) =>
+      Promise.all([
+        Project.getById(params.projectId)
+          .then(getOrNotFound)
+          .then((project) => auth.canOrReject('submission.update', project)
+            .then(() => project.getFormByXmlFormId(params.formId))
+            .then(getOrNotFound)
+            .then((form) => Submission.getById(form.id, params.instanceId))
+            .then(getOrNotFound)),
+        Blob.fromStream(request, headers['content-type'])
+          .then((blob) => blob.create())
+      ])
+        // TODO: audit-log creation? (but we don't do it when via openrosa..)
+        .then(([ submission, blob ]) => submission.attach(params.name, blob))
+        .then(success))
+  );
+
+  service.delete(
+    '/projects/:projectId/forms/:formId/submissions/:instanceId/attachments/:name',
+    endpoint(({ Audit, Project, Submission, SubmissionAttachment }, { params, headers, auth }, request) =>
+      Project.getById(params.projectId)
+        .then(getOrNotFound)
+        .then((project) => auth.canOrReject('submission.update', project)
+          .then(() => project.getFormByXmlFormId(params.formId))
+          .then(getOrNotFound)
+          // TODO: as with above (copy+paste) can be more performant+compact via a custom join.
+          .then((form) => Submission.getById(form.id, params.instanceId)
+            .then(getOrNotFound)
+            .then((submission) => SubmissionAttachment.getBySubmission(submission.id, params.name))
+            .then(getOrNotFound)
+            .then((attachment) => Promise.all([
+              attachment.delete(),
+              Audit.log(auth.actor(), 'submission.attachment.delete', form, { name: attachment.name, blobId: attachment.blobId })
+            ]))
+            .then(success))))
+  );
+};
 

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -104,8 +104,10 @@ module.exports = (service, endpoint) => {
             always(Problem.user.notAcceptingSubmissions())
           ))
           .then((partial) => partial.complete(form, auth.actor()).create())
-          .then((submission) => submission.createExpectedAttachments(form)
-            .then(() => Audit.log(auth.actor(), 'submission.create', form, { submissionId: submission.id }))
+          .then((submission) => Promise.all([
+            submission.createExpectedAttachments(form),
+            Audit.log(auth.actor(), 'submission.create', form, { submissionId: submission.id })
+          ])
             .then(always(submission)))))));
 
   service.get('/projects/:projectId/forms/:id/submissions.csv.zip', endpoint(({ all, Project, Submission, SubmissionAttachment }, { params, auth }, _, response) =>

--- a/lib/util/promise.js
+++ b/lib/util/promise.js
@@ -32,7 +32,6 @@ const getOrNotFound = getOrReject(Problem.user.notFound());
 // given Problem if the predicate returns anything but true. Otherwise passes through.
 const rejectIf = (predicate, problem) => (value) => ((predicate(value) === true) ? reject(problem(value)) : value);
 
-// TODO/CR: better name?
 // given a lambda, will then give a function that takes an argument, applies it to
 // the lambda, but ignores the result of the lambda and just gives the argument.
 // eg: .then(ignoringResult((value) => value.doAction())) => returns value

--- a/lib/util/promise.js
+++ b/lib/util/promise.js
@@ -32,9 +32,15 @@ const getOrNotFound = getOrReject(Problem.user.notFound());
 // given Problem if the predicate returns anything but true. Otherwise passes through.
 const rejectIf = (predicate, problem) => (value) => ((predicate(value) === true) ? reject(problem(value)) : value);
 
+// TODO/CR: better name?
+// given a lambda, will then give a function that takes an argument, applies it to
+// the lambda, but ignores the result of the lambda and just gives the argument.
+// eg: .then(ignoringResult((value) => value.doAction())) => returns value
+const ignoringResult = (f) => (x) => f(x).then(() => x);
+
 
 module.exports = {
   reject, resolve,
-  getOrElse, getOrReject, getOrNotFound, rejectIf
+  getOrElse, getOrReject, getOrNotFound, rejectIf, ignoringResult
 };
 

--- a/lib/util/stream.js
+++ b/lib/util/stream.js
@@ -9,13 +9,22 @@ const mapStream = (f) => new Transform({
   }
 });
 
+// given a stream, takes a map function that turns each stream object into either
+// a Some(Promise) or a None. returns Promise.all on all the returned Promises.
+const mapStreamToPromises = (map, stream) => new Promise((resolve, reject) => {
+  const promises = [];
+  stream.on('data', (obj) => map(obj).ifDefined((promise) => { promises.push(promise); }));
+  stream.on('error', reject);
+  stream.on('end', () => { resolve(Promise.all(promises)); });
+});
+
 // helper for the two *AndBuffer utilities below which handles the buffering
 // and promise formulation part.
 const _xAndBuffer = (stream, promises) => {
   const bufs = [];
   const bufferPromise = new Promise((resolve, reject) => {
     stream.on('data', (chunk) => { bufs.push(chunk); });
-    stream.on('error', (err) => { reject(err); });
+    stream.on('error', reject);
     stream.on('end', () => { resolve(Buffer.concat(bufs)); });
   });
 
@@ -47,5 +56,5 @@ const passthroughAndBuffer = (inStream, ...fs) => {
   return _xAndBuffer(stream, promises);
 };
 
-module.exports = { mapStream, consumeAndBuffer, passthroughAndBuffer };
+module.exports = { mapStream, mapStreamToPromises, consumeAndBuffer, passthroughAndBuffer };
 

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -11,11 +11,24 @@
 
 const { inspect } = require('util');
 
+////////////////////////////////////////
+// FUNCTIONS
+
 const noop = () => {};
+
+
+////////////////////////////////////////
+// VALUES
 
 // Checks for a variety of falsy values. Useful for dropping API input noise.
 const isBlank = (x) => (x === null) || (x === undefined) || (x === '');
 const isPresent = (x) => !isBlank(x);
+
+const blankStringToNull = (x) => ((x === '') ? null : x);
+
+
+////////////////////////////////////////
+// OBJECTS
 
 // Given an object, prints a human-readable representation of it. Used to return
 // debug information to API users.
@@ -36,13 +49,19 @@ const without = (keys, obj) => {
   return result;
 };
 
+
+////////////////////////////////////////
+// ARRAYS
+
 // Given Array[Any]|Any, returns the input if it is already an array, or else wraps
 // the input in an array.
 const ensureArray = (x) => (Array.isArray(x) ? x : [ x ]);
 
-const blankStringToNull = (x) => ((x === '') ? null : x);
 
+////////////////////////////////////////
+// CLASSES
 // ES6 classes really suck here are some helpers to make them not.
+
 // for instance, there is no way to invoke a parent instance method. here is a
 // workaround to make that process less than nightmarish.
 //
@@ -60,5 +79,12 @@ const superproto = (x) => {
   return new Proxy(Object.getPrototypeOf(Object.getPrototypeOf(x)), proxy);
 };
 
-module.exports = { noop, isBlank, isPresent, printPairs, without, blankStringToNull, ensureArray, superproto };
+
+module.exports = {
+  noop,
+  isBlank, isPresent, blankStringToNull,
+  printPairs, without,
+  ensureArray,
+  superproto
+};
 

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -87,17 +87,61 @@ describe('api: /submission', () => {
     // no point in replicating it.
     it('should save given attachments', testService((service) =>
       service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/submission')
-          .set('X-OpenRosa-Version', '1.0')
-          .attach('file1.txt', Buffer.from('this is test file one'), { filename: 'file1.txt' })
-          .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
-          .attach('file2.txt', Buffer.from('this is test file two'), { filename: 'file2.txt' })
-          .expect(201)
-          .then(() => asAlice.get('/v1/projects/1/forms/simple/submissions/one/attachments')
-            .expect(200)
-            .then(({ body }) => {
-              body.should.containDeep([ 'file1.txt', 'file2.txt' ]);
-            })))));
+        asAlice.post('/v1/projects/1/forms')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/submission')
+            .set('X-OpenRosa-Version', '1.0')
+            .attach('my_file1.mp4', Buffer.from('this is test file one'), { filename: 'my_file1.mp4' })
+            .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
+            .attach('here_is_file2.jpg', Buffer.from('this is test file two'), { filename: 'here_is_file2.jpg' })
+            .expect(201)
+            .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/both/attachments')
+              .expect(200)
+              .then(({ body }) => {
+                body.should.eql([
+                  { name: 'my_file1.mp4', exists: true },
+                  { name: 'here_is_file2.jpg', exists: true }
+                ]);
+              }))))));
+
+    it('should ignore unknown attachments', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/submission')
+            .set('X-OpenRosa-Version', '1.0')
+            .attach('some_random_file', Buffer.from('this is test file one'), { filename: 'some_random_file' })
+            .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
+            .attach('other_random_file', Buffer.from('this is test file two'), { filename: 'other_random_file' })
+            .expect(201)
+            .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/both/attachments')
+              .expect(200)
+              .then(({ body }) => {
+                body.should.eql([
+                  { name: 'my_file1.mp4', exists: false },
+                  { name: 'here_is_file2.jpg', exists: false }
+                ]);
+              }))))));
+
+    it('should detect which attachments are expected', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/submission')
+            .set('X-OpenRosa-Version', '1.0')
+            .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.one), { filename: 'data.xml' })
+            .expect(201)
+            .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/one/attachments')
+              .expect(200)
+              .then(({ body }) => {
+                body.should.eql([{ name: 'my_file1.mp4', exists: false }]);
+              }))))));
 
     it('should reject if the xml changes between posts', testService((service) =>
       service.login('alice', (asAlice) =>
@@ -115,50 +159,73 @@ describe('api: /submission', () => {
 
     it('should take in additional attachments via additional POSTs', testService((service) =>
       service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/submission')
-          .set('X-OpenRosa-Version', '1.0')
-          .attach('file1.txt', Buffer.from('this is test file one'), { filename: 'file1.txt' })
-          .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
-          .expect(201)
+        asAlice.post('/v1/projects/1/forms')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200)
           .then(() => asAlice.post('/v1/projects/1/submission')
             .set('X-OpenRosa-Version', '1.0')
-            .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
-            .attach('file2.txt', Buffer.from('this is test file two'), { filename: 'file2.txt' })
+            .attach('my_file1.mp4', Buffer.from('this is test file one'), { filename: 'my_file1.mp4' })
+            .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
             .expect(201)
-            .then(() => asAlice.get('/v1/projects/1/forms/simple/submissions/one/attachments')
-              .expect(200)
-              .then(({ body }) => {
-                body.should.eql([ 'file1.txt', 'file2.txt' ]);
-              }))))));
-
-    it('should reject given conflicting attachment names', testService((service) =>
-      service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/submission')
-          .set('X-OpenRosa-Version', '1.0')
-          .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
-          .attach('file1.txt', Buffer.from('this is test file one'), { filename: 'file1.txt' })
-          .attach('file1.txt', Buffer.from('this is test file two'), { filename: 'file2.txt' })
-          .expect(400)
-          .then(({ text }) => {
-            text.should.match(/resource already exists with \(attachment file names\) value\(s\) of file1.txt/);
-          }))));
+            .then(() => asAlice.post('/v1/projects/1/submission')
+              .set('X-OpenRosa-Version', '1.0')
+              .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
+              .attach('here_is_file2.jpg', Buffer.from('this is test file two'), { filename: 'here_is_file2.jpg' })
+              .expect(201)
+              .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/both/attachments')
+                .expect(200)
+                .then(({ body }) => {
+                  body.should.eql([
+                    { name: 'here_is_file2.jpg', exists: true },
+                    { name: 'my_file1.mp4', exists: true }
+                  ]);
+                })))))));
 
     // also tests /forms/_/submissions/_/attachments/_ return content. (mark2)
     // no point in replicating it.
     it('should successfully save attachment binary data', testService((service) =>
       service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/submission')
-          .set('X-OpenRosa-Version', '1.0')
-          .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
-          .attach('file1.txt', Buffer.from('this is test file one'), { filename: 'file1.txt' })
-          .expect(201)
-          .then(() => asAlice.get('/v1/projects/1/forms/simple/submissions/one/attachments/file1.txt')
-            .expect(200)
-            .then(({ headers, text }) => {
-              headers['content-type'].should.equal('text/plain; charset=utf-8');
-              headers['content-disposition'].should.equal('attachment; filename="file1.txt"');
-              text.should.equal('this is test file one');
-            })))));
+        asAlice.post('/v1/projects/1/forms')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/submission')
+            .set('X-OpenRosa-Version', '1.0')
+            .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
+            .attach('my_file1.mp4', Buffer.from('this is test file one'), { filename: 'my_file1.mp4' })
+            .expect(201)
+            .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+              .expect(200)
+              .then(({ headers, body }) => {
+                headers['content-type'].should.equal('video/mp4');
+                headers['content-disposition'].should.equal('attachment; filename="my_file1.mp4"');
+                body.toString('utf8').should.equal('this is test file one');
+              }))))));
+
+    it('should successfully save additionally POSTed attachment binary data', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/submission')
+            .set('X-OpenRosa-Version', '1.0')
+            .attach('my_file1.mp4', Buffer.from('this is test file one'), { filename: 'my_file1.mp4' })
+            .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
+            .expect(201)
+            .then(() => asAlice.post('/v1/projects/1/submission')
+              .set('X-OpenRosa-Version', '1.0')
+              .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
+              .attach('here_is_file2.jpg', Buffer.from('this is test file two'), { filename: 'here_is_file2.jpg' })
+              .expect(201)
+              .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/both/attachments/here_is_file2.jpg')
+                .expect(200)
+                .then(({ headers, body }) => {
+                  headers['content-type'].should.equal('image/jpeg');
+                  headers['content-disposition'].should.equal('attachment; filename="here_is_file2.jpg"');
+                  body.toString('utf8').should.equal('this is test file two');
+                })))))));
   });
 });
 
@@ -246,6 +313,25 @@ describe('api: /forms/:id/submissions', () => {
             body.createdAt.should.be.a.recentIsoDate();
             body.submitter.should.equal(5);
           }))));
+
+    it('should create expected attachments', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions')
+            .send(testData.instances.binaryType.both)
+            .set('Content-Type', 'text/xml')
+            .expect(200)
+            .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/both/attachments')
+              .expect(200)
+              .then(({ body }) => {
+                body.should.eql([
+                  { name: 'my_file1.mp4', exists: false },
+                  { name: 'here_is_file2.jpg', exists: false }
+                ]);
+              }))))));
   });
 
   describe('.csv.zip GET', () => {
@@ -279,32 +365,33 @@ describe('api: /forms/:id/submissions', () => {
 
     it('should return a zipfile with the relevant attachments', testService((service) =>
       service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/submission')
-          .set('X-OpenRosa-Version', '1.0')
-          .attach('xml_submission_file', Buffer.from(testData.instances.simple.one), { filename: 'data.xml' })
-          .attach('file1.txt', Buffer.from('this is test file one'), { filename: 'file1.txt' })
-          .attach('file2.txt', Buffer.from('this is test file two'), { filename: 'file2.txt' })
-          .expect(201)
+        asAlice.post('/v1/projects/1/forms')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200)
           .then(() => asAlice.post('/v1/projects/1/submission')
             .set('X-OpenRosa-Version', '1.0')
-            .attach('xml_submission_file', Buffer.from(testData.instances.simple.two), { filename: 'data.xml' })
-            .attach('file3.txt', Buffer.from('this is test file three'), { filename: 'file3.txt' })
-            .expect(201))
-          .then(() => new Promise((done) =>
-            zipStreamToFiles(asAlice.get('/v1/projects/1/forms/simple/submissions.csv.zip'), (result) => {
-              result.filenames.should.containDeep([
-                'simple.csv',
-                'media/file1.txt',
-                'media/file2.txt',
-                'media/file3.txt'
-              ]);
+            .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
+            .attach('my_file1.mp4', Buffer.from('this is test file one'), { filename: 'my_file1.mp4' })
+            .expect(201)
+            .then(() => asAlice.post('/v1/projects/1/submission')
+              .set('X-OpenRosa-Version', '1.0')
+              .attach('xml_submission_file', Buffer.from(testData.instances.binaryType.both), { filename: 'data.xml' })
+              .attach('here_is_file2.jpg', Buffer.from('this is test file two'), { filename: 'here_is_file2.jpg' })
+              .expect(201))
+            .then(() => new Promise((done) =>
+              zipStreamToFiles(asAlice.get('/v1/projects/1/forms/binaryType/submissions.csv.zip'), (result) => {
+                result.filenames.should.containDeep([
+                  'binaryType.csv',
+                  'media/my_file1.mp4',
+                  'media/here_is_file2.jpg'
+                ]);
 
-              result['media/file1.txt'].should.equal('this is test file one');
-              result['media/file2.txt'].should.equal('this is test file two');
-              result['media/file3.txt'].should.equal('this is test file three');
+                result['media/my_file1.mp4'].should.equal('this is test file one');
+                result['media/here_is_file2.jpg'].should.equal('this is test file two');
 
-              done();
-            }))))));
+                done();
+              })))))));
   });
 
   describe('GET', () => {
@@ -505,22 +592,41 @@ describe('api: /forms/:id/submissions', () => {
           .send('testimage')
           .expect(403))));
 
+    it('should reject if the attachment does not exist', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.post('/v1/projects/1/forms')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
+          .expect(200)
+          .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions')
+            .send(testData.instances.binaryType.both)
+            .set('Content-Type', 'text/xml')
+            .expect(200)
+            .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions/both/attachments/cool_file3.mp3')
+              .set('Content-Type', 'audio/mp3')
+              .send('testaudio')
+              .expect(404))))));
+
     it('should attach the given file', testService((service) =>
       service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/forms/simple/submissions')
-          .send(testData.instances.simple.one)
-          .set('Content-Type', 'text/xml')
+        asAlice.post('/v1/projects/1/forms')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
           .expect(200)
-          .then(() => asAlice.post('/v1/projects/1/forms/simple/submissions/one/attachments/file.jpg')
-            .set('Content-Type', 'image/jpeg')
-            .send('testimage')
+          .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions')
+            .send(testData.instances.binaryType.both)
+            .set('Content-Type', 'text/xml')
             .expect(200)
-            .then(() => asAlice.get('/v1/projects/1/forms/simple/submissions/one/attachments/file.jpg')
+            .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+              .set('Content-Type', 'video/mp4')
+              .send('testvideo')
               .expect(200)
-              .then(({ headers, body }) => {
-                headers['content-type'].should.equal('image/jpeg');
-                body.toString().should.equal('testimage');
-              }))))));
+              .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+                .expect(200)
+                .then(({ headers, body }) => {
+                  headers['content-type'].should.equal('video/mp4');
+                  body.toString().should.equal('testvideo');
+                })))))));
   });
 
   describe('/:instanceId/attachments/:name DELETE', () => {
@@ -545,47 +651,64 @@ describe('api: /forms/:id/submissions', () => {
           .send('testimage')
           .expect(403))));
 
-    it('should delete the given attachment', testService((service) =>
+    it('should clear the given attachment', testService((service) =>
       service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/forms/simple/submissions')
-          .send(testData.instances.simple.one)
-          .set('Content-Type', 'text/xml')
+        asAlice.post('/v1/projects/1/forms')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
           .expect(200)
-          .then(() => asAlice.post('/v1/projects/1/forms/simple/submissions/one/attachments/file.jpg')
-            .set('Content-Type', 'image/jpeg')
-            .send('testimage')
+          .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions')
+            .send(testData.instances.binaryType.both)
+            .set('Content-Type', 'text/xml')
             .expect(200)
-            .then(() => asAlice.delete('/v1/projects/1/forms/simple/submissions/one/attachments/file.jpg')
+            .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+              .set('Content-Type', 'video/mp4')
+              .send('testvideo')
               .expect(200)
-              .then(() => asAlice.get('/v1/projects/1/forms/simple/submissions/one/attachments/file.jpg')
-                .expect(404)))))));
+              .then(() => asAlice.delete('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+                .expect(200)
+                .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+                  .expect(404)
+                  .then(() => asAlice.get('/v1/projects/1/forms/binaryType/submissions/both/attachments')
+                    .expect(200)
+                    .then(({ body }) =>  {
+                      body.should.eql([
+                        { name: 'my_file1.mp4', exists: false },
+                        { name: 'here_is_file2.jpg', exists: false }
+                      ]);
+                    })))))))));
 
-    it('should log an audit entry about the deletion', testService((service, { Audit, Form }) =>
+    it('should log an audit entry about the deletion', testService((service, { Audit, Project }) =>
       service.login('alice', (asAlice) =>
-        asAlice.post('/v1/projects/1/forms/simple/submissions')
-          .send(testData.instances.simple.one)
-          .set('Content-Type', 'text/xml')
+        asAlice.post('/v1/projects/1/forms')
+          .set('Content-Type', 'application/xml')
+          .send(testData.forms.binaryType)
           .expect(200)
-          .then(() => asAlice.post('/v1/projects/1/forms/simple/submissions/one/attachments/file.jpg')
-            .set('Content-Type', 'image/jpeg')
-            .send('testimage')
+          .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions')
+            .send(testData.instances.binaryType.both)
+            .set('Content-Type', 'text/xml')
             .expect(200)
-            .then(() => asAlice.delete('/v1/projects/1/forms/simple/submissions/one/attachments/file.jpg')
+            .then(() => asAlice.post('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+              .set('Content-Type', 'video/mp4')
+              .send('testvideo')
               .expect(200)
-              .then(() => Promise.all([
-                asAlice.get('/v1/users/current').expect(200),
-                Form.getByXmlFormId('simple'), // TODO/CR: sort of imprecise
-                Audit.getLatestWhere({ action: 'submission.attachment.delete' })
-              ])
-                .then(([ user, maybeSubmission, maybeLog ]) => {
-                  maybeLog.isDefined().should.equal(true);
-                  const log = maybeLog.get();
+              .then(() => asAlice.delete('/v1/projects/1/forms/binaryType/submissions/both/attachments/my_file1.mp4')
+                .expect(200)
+                .then(() => Promise.all([
+                  asAlice.get('/v1/users/current').expect(200),
+                  Project.getById(1)
+                    .then((project) => project.get().getFormByXmlFormId('binaryType')),
+                  Audit.getLatestWhere({ action: 'submission.attachment.clear' })
+                ])
+                  .then(([ user, maybeForm, maybeLog ]) => {
+                    maybeLog.isDefined().should.equal(true);
+                    const log = maybeLog.get();
 
-                  log.actorId.should.equal(user.body.id);
-                  log.acteeId.should.equal(maybeSubmission.get().acteeId);
-                  log.details.name.should.equal('file.jpg');
-                  log.details.blobId.should.be.a.Number();
-                })))))));
+                    log.actorId.should.equal(user.body.id);
+                    log.acteeId.should.equal(maybeForm.get().acteeId);
+                    log.details.name.should.equal('my_file1.mp4');
+                    log.details.blobId.should.be.a.Number();
+                  }))))))));
   });
 });
 

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -101,8 +101,8 @@ describe('api: /submission', () => {
               .expect(200)
               .then(({ body }) => {
                 body.should.eql([
-                  { name: 'my_file1.mp4', exists: true },
-                  { name: 'here_is_file2.jpg', exists: true }
+                  { name: 'here_is_file2.jpg', exists: true },
+                  { name: 'my_file1.mp4', exists: true }
                 ]);
               }))))));
 
@@ -122,8 +122,8 @@ describe('api: /submission', () => {
               .expect(200)
               .then(({ body }) => {
                 body.should.eql([
-                  { name: 'my_file1.mp4', exists: false },
-                  { name: 'here_is_file2.jpg', exists: false }
+                  { name: 'here_is_file2.jpg', exists: false },
+                  { name: 'my_file1.mp4', exists: false }
                 ]);
               }))))));
 
@@ -328,8 +328,8 @@ describe('api: /forms/:id/submissions', () => {
               .expect(200)
               .then(({ body }) => {
                 body.should.eql([
-                  { name: 'my_file1.mp4', exists: false },
-                  { name: 'here_is_file2.jpg', exists: false }
+                  { name: 'here_is_file2.jpg', exists: false },
+                  { name: 'my_file1.mp4', exists: false }
                 ]);
               }))))));
   });
@@ -673,8 +673,8 @@ describe('api: /forms/:id/submissions', () => {
                     .expect(200)
                     .then(({ body }) =>  {
                       body.should.eql([
-                        { name: 'my_file1.mp4', exists: false },
-                        { name: 'here_is_file2.jpg', exists: false }
+                        { name: 'here_is_file2.jpg', exists: false },
+                        { name: 'my_file1.mp4', exists: false }
                       ]);
                     })))))))));
 

--- a/test/integration/data.js
+++ b/test/integration/data.js
@@ -193,6 +193,35 @@ module.exports = {
       </itext>
     </model>
   </h:head>
+</h:html>`,
+    binaryType: `<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+  <h:head>
+    <h:title>Submission </h:title>
+    <model>
+      <instance>
+        <data id="binaryType">
+          <meta>
+            <instanceID/>
+          </meta>
+          <file1/>
+          <file2/>
+        </data>
+      </instance>
+
+      <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
+      <bind nodeset="/data/file1" type="binary"/>
+      <bind nodeset="/data/file2" type="binary"/>
+    </model>
+
+  </h:head>
+  <h:body>
+    <upload ref="/data/file1" accept="image/*">
+      <label>Give me an image.</label>
+    </upload>
+    <upload ref="/data/file2" accept="video/*">
+      <label>Give me a video./label>
+    </upload>
+  </h:body>
 </h:html>`
   },
   instances: {
@@ -239,6 +268,11 @@ module.exports = {
       </child>
     </children>
   </data>`
+    },
+    binaryType: {
+      one: instance('binaryType', 'one', '<file1>my_file1.mp4</file1>'),
+      two: instance('binaryType', 'two', '<file2>here_is_file2.jpg</file2>'),
+      both: instance('binaryType', 'both', '<file1>my_file1.mp4</file1><file2>here_is_file2.jpg</file2>')
     }
   }
 };

--- a/test/unit/data/submission.js
+++ b/test/unit/data/submission.js
@@ -1,0 +1,46 @@
+require('should');
+const appRoot = require('app-root-path');
+const { always } = require('ramda');
+const { toObjects } = require('streamtest').v2;
+const { submissionToFieldStream } = require(appRoot + '/lib/data/submission');
+const { getFormSchema } = require(appRoot + '/lib/data/schema');
+const testData = require(appRoot + '/test/integration/data');
+
+describe('submission field streamer', () => {
+  const mockForm = (xml) => ({ schema: always(getFormSchema({ xml })) });
+
+  it('should return a stream of records', (done) => {
+    submissionToFieldStream({ xml: testData.instances.simple.one }, mockForm(testData.forms.simple))
+      .then((fieldStream) => fieldStream.pipe(toObjects((error, result) => {
+        result.should.eql([
+          { field: { name: 'instanceID', type: 'string' }, text: 'one' },
+          { field: { name: 'name', type: 'string' }, text: 'Alice' },
+          { field: { name: 'age', type: 'int' }, text: '30' }
+        ]);
+        done();
+      })));
+  });
+
+  it('should deal correctly with repeats', (done) => {
+    submissionToFieldStream({ xml: testData.instances.doubleRepeat.double }, mockForm(testData.forms.doubleRepeat))
+      .then((fieldStream) => fieldStream.pipe(toObjects((error, result) => {
+        result.should.eql([
+          { field: { name: 'instanceID', type: 'string' }, text: 'double' },
+          { field: { name: 'name', type: 'string' }, text: 'Vick' },
+          { field: { name: 'name', type: 'string' }, text: 'Alice' },
+          { field: { name: 'name', type: 'string' }, text: 'Bob' },
+          { field: { name: 'name', type: 'string' }, text: 'Twilight Sparkle' },
+          { field: { name: 'name', type: 'string' }, text: 'Pinkie Pie' },
+          { field: { name: 'name', type: 'string' }, text: 'Applejack' },
+          { field: { name: 'name', type: 'string' }, text: 'Spike' },
+          { field: { name: 'name', type: 'string' }, text: 'Chelsea' },
+          { field: { name: 'name', type: 'string' }, text: 'Rainbow Dash' },
+          { field: { name: 'name', type: 'string' }, text: 'Rarity' },
+          { field: { name: 'name', type: 'string' }, text: 'Fluttershy' },
+          { field: { name: 'name', type: 'string' }, text: 'Princess Luna' }
+        ]);
+        done();
+      })));
+  });
+});
+

--- a/test/unit/util/stream.js
+++ b/test/unit/util/stream.js
@@ -1,0 +1,26 @@
+require('should');
+const appPath = require('app-root-path');
+const { mapStreamToPromises } = require(appPath + '/lib/util/stream');
+const Option = require(appPath + '/lib/util/option');
+const { fromObjects } = require('streamtest').v2;
+
+describe('stream utils', () => {
+  describe('mapStreamToPromises', () => {
+    it('should return a promise of mapped promises', () =>
+      mapStreamToPromises(
+        (num) => Option.of(Promise.resolve(num)),
+        fromObjects([ 4, 8, 15, 16, 23, 42 ])
+      ).then((results) => {
+        results.should.eql([ 4, 8, 15, 16, 23, 42 ]);
+      }));
+
+    it('should ignore None results', () =>
+      mapStreamToPromises(
+        (num) => Option.of((num % 2) ? null : Promise.resolve(num)),
+        fromObjects([ 4, 8, 15, 16, 23, 42 ])
+      ).then((results) => {
+        results.should.eql([ 4, 8, 16, 42 ]);
+      }));
+  });
+});
+


### PR DESCRIPTION
1. adds `POST attachments/:name` and `DELETE attachments/:name`
2. also refactors the entire submission attachment process to look like the form attachment process: expected attachments are determined by the submission xml, and the attachment record exists whether the binary does or not. unknown files are now ignored.