### PR TITLE
improve #151: email notifications for password/email changes

### DIFF
--- a/lib/outbound/mail.js
+++ b/lib/outbound/mail.js
@@ -33,6 +33,9 @@ const messages = {
   // * {{token}} is the auth token that grants access to this operation.
   accountCreated: message('ODK Central account created', '<html>Hello!<p>An account has been provisioned for you on an ODK Central data collection server.</p><p>If this message is unexpected, simply ignore it. Otherwise, please visit the following link to set your password and claim your account:</p><p>{{domain}}/#/account/claim?token={{token}}</p><p>The link is valid for 24 hours. After that, you will have to request a new one using the Reset Password tool.</p></html>'),
 
+  // Notifies a user that their account's email has been changed
+  accountEmailChanged: message('ODK Central account email changed', '<html>Hello!<p><p>We are emailing because you have an ODK Central data collection account, and somebody has just changed the email address associated with the account from this one you are reading right now ({{oldEmail}}) to a new address ({{newEmail}}).</p><p>If this was you, please feel free to ignore this email. Otherwise, please contact your local ODK system administrator immediately.</p></html>'),
+
   // Notifies a user that a password reset has been initialted for their email;
   // gives them the link required to set their password.
   // * {{token}} is the auth token that grants access to this operation.
@@ -40,7 +43,10 @@ const messages = {
 
   // Notifies an email address that a password reset has been initiated, but that
   // no account exists at this address.
-  accountResetFailure: message('ODK Central account password reset', '<html>Hello!<p>A password reset has been requested for this email address, but no account exists with this address.</p><p>If this message is unexpected, simply ignore it. Otherwise, please double check the email address given for your account, and try again using the Reset Password tool.</p></html>')
+  accountResetFailure: message('ODK Central account password reset', '<html>Hello!<p>A password reset has been requested for this email address, but no account exists with this address.</p><p>If this message is unexpected, simply ignore it. Otherwise, please double check the email address given for your account, and try again using the Reset Password tool.</p></html>'),
+
+  // Notifies a user that their password has been changed
+  accountPasswordChanged: message('ODK Central account password change', '<html>Hello!<p>We are emailing because you have an ODK Central data collection account, and somebody has just changed its password.</p><p>If this was you, please feel free to ignore this email.</p><p>Otherwise, please contact your local ODK system administrator immediately.</p></html>')
 };
 
 

--- a/lib/resources/users.js
+++ b/lib/resources/users.js
@@ -11,6 +11,7 @@ const { success, isTrue } = require('../util/http');
 const { verifyPassword } = require('../util/crypto');
 const Problem = require('../util/problem');
 const { resolve, reject, getOrNotFound } = require('../util/promise');
+const { isPresent } = require('../util/util');
 
 module.exports = (service, endpoint) => {
 
@@ -80,21 +81,29 @@ module.exports = (service, endpoint) => {
         .then(() => user))));
 
   // TODO: infosec debate around 404 vs 403 if insufficient privs but record DNE.
-  service.patch('/users/:id', endpoint(({ User }, { params, body, auth }) =>
+  service.patch('/users/:id', endpoint(({ User, mail }, { params, body, auth }) =>
     User.getByActorId(params.id)
       .then(getOrNotFound)
       .then((user) => auth.canOrReject('user.update', user.actor)
-        .then(() => user.with(User.fromApi(body)).update()))));
+        .then(() => user.with(User.fromApi(body)).update())
+        .then((response) => {
+          if (isPresent(body.email) && body.email !== user.email) {
+            mail(user.email, 'accountEmailChanged', { oldEmail: user.email, newEmail: body.email });
+          }
+          return response;
+        }))));
 
   // TODO: ditto infosec debate.
   // TODO: exact endpoint naming.
-  service.put('/users/:id/password', endpoint(({ User }, { params, body, auth }) =>
+  service.put('/users/:id/password', endpoint(({ User, mail }, { params, body, auth }) =>
     User.getByActorId(params.id)
       .then(getOrNotFound)
       .then((user) => auth.canOrReject('user.update', user.actor)
         .then(() => verifyPassword(body.old, user.password)
           .then((verified) => ((verified === true)
-            ? user.updatePassword(body.new).then(success)
+            ? user.updatePassword(body.new)
+              .then(() => mail(user.email, 'accountPasswordChanged'))
+              .then(success)
             : Problem.user.authenticationFailed()))))));
 };
 

--- a/lib/resources/users.js
+++ b/lib/resources/users.js
@@ -86,11 +86,12 @@ module.exports = (service, endpoint) => {
       .then(getOrNotFound)
       .then((user) => auth.canOrReject('user.update', user.actor)
         .then(() => user.with(User.fromApi(body)).update())
-        .then((response) => {
+        .then((result) => {
           if (isPresent(body.email) && body.email !== user.email) {
-            mail(user.email, 'accountEmailChanged', { oldEmail: user.email, newEmail: body.email });
+            return mail(user.email, 'accountEmailChanged', { oldEmail: user.email, newEmail: body.email })
+              .then(() => result);
           }
-          return response;
+          return result;
         }))));
 
   // TODO: ditto infosec debate.

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -253,6 +253,7 @@ describe('api: /users', () => {
               global.inbox.length.should.equal(0);
               email.to.should.eql([{ address: 'alice@opendatakit.org', name: '' }]);
               email.subject.should.equal('ODK Central account email changed');
+              email.html.should.equal('<html>Hello!<p><p>We are emailing because you have an ODK Central data collection account, and somebody has just changed the email address associated with the account from this one you are reading right now (alice@opendatakit.org) to a new address (david123@opendatakit.org).</p><p>If this was you, please feel free to ignore this email. Otherwise, please contact your local ODK system administrator immediately.</p></html>');
             })))));
 
     it('should not send an email to a user when their email does not change', testService((service) =>

--- a/test/integration/api/users.js
+++ b/test/integration/api/users.js
@@ -240,6 +240,31 @@ describe('api: /users', () => {
                 .send({ email: 'newalice@odk.org', password: 'alice' })
                 .expect(200);
             })))));
+
+    it('should send an email to the user\'s previous email when their email changes', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.get('/v1/users/current')
+          .expect(200)
+          .then((before) => asAlice.patch(`/v1/users/${before.body.id}`)
+            .send({ email: 'david123@opendatakit.org' })
+            .expect(200)
+            .then(() => {
+              const email = global.inbox.pop();
+              global.inbox.length.should.equal(0);
+              email.to.should.eql([{ address: 'alice@opendatakit.org', name: '' }]);
+              email.subject.should.equal('ODK Central account email changed');
+            })))));
+
+    it('should not send an email to a user when their email does not change', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.get('/v1/users/current')
+          .expect(200)
+          .then((before) => asAlice.patch(`/v1/users/${before.body.id}`)
+            .send({ email: 'alice@opendatakit.org' })
+            .expect(200)
+            .then(() => {
+              global.inbox.length.should.equal(0);
+            })))));
   });
 
   describe('/users/:id/password PUT', () => {
@@ -279,6 +304,20 @@ describe('api: /users', () => {
               .send({ email: 'alice@opendatakit.org', password: 'newpassword' })
               .expect(200);
           }))));
+
+    it('should send an email to a user when their password changes', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.get('/v1/users/current')
+          .expect(200)
+          .then(({ body }) => asAlice.put(`/v1/users/${body.id}/password`)
+            .send({ old: 'alice', new: 'newpassword' })
+            .expect(200)
+            .then(() => {
+              const email = global.inbox.pop();
+              global.inbox.length.should.equal(0);
+              email.to.should.eql([{ address: 'alice@opendatakit.org', name: '' }]);
+              email.subject.should.equal('ODK Central account password change');
+            })))));
   });
 });
 


### PR DESCRIPTION
#151 Adds email notifications when a user updates their email address or password. When a user changes their email address, the email is sent to the email address which was previously on file.