### PR TITLE
improve #150: adds storage of device id on submit

### DIFF
--- a/lib/model/instance/submission.js
+++ b/lib/model/instance/submission.js
@@ -36,28 +36,33 @@ const out = {};
 
 // TODO/CR: should this be in its own file for consistency?
 out.PartialSubmission = Instance()(({ Submission }) => class {
-  complete(form, maybeActor) {
+  complete(form, maybeActor, maybeDeviceId) {
     // TODO it's awkward that this error/message is thrown here; should be closer to edge.
     if (this.version !== form.version)
       throw Problem.user.unexpectedValue({ field: 'version', value: this.version, reason: 'The submission could not be accepted because your copy of this form is an outdated version. Please get the latest version and try again.' });
 
     const actorId = Option.of(maybeActor).map((actor) => actor.id).orNull();
-    return new Submission(this.without('xmlFormId', 'version').with({ formId: form.id, submitter: actorId }));
+    const deviceId = blankStringToNull(maybeDeviceId);
+    return new Submission(this.without('xmlFormId', 'version').with({
+      formId: form.id,
+      submitter: actorId,
+      deviceId
+    }));
   }
 });
 
 /* eslint-disable */ // because its newline requirements here are insane.
 const ExtendedSubmission = ExtendedInstance({
   fields: {
-    readable: [ 'instanceId', 'xml', 'submitter', 'createdAt', 'updatedAt' ]
+    readable: [ 'instanceId', 'xml', 'submitter', 'createdAt', 'updatedAt', 'deviceId' ]
   },
   forApi() { return merge(superproto(this).forApi(), { submitter: this.submitter.forApi() }); }
 });
 /* eslint-enable */
 
 out.Submission = Instance.with(HasExtended(ExtendedSubmission))('submissions', {
-  all: [ 'id', 'formId', 'instanceId', 'xml', 'submitter', 'createdAt', 'updatedAt', 'deletedAt' ],
-  readable: [ 'instanceId', 'submitter', 'createdAt', 'updatedAt' ]
+  all: [ 'id', 'formId', 'instanceId', 'xml', 'submitter', 'createdAt', 'updatedAt', 'deletedAt', 'deviceId' ],
+  readable: [ 'instanceId', 'submitter', 'createdAt', 'updatedAt', 'deviceId' ]
 })(({ PartialSubmission, SubmissionAttachment, Blob, simply, submissions }) => class {
 
   forCreate() { return withCreateTime(this); }

--- a/lib/model/instance/submission.js
+++ b/lib/model/instance/submission.js
@@ -36,17 +36,17 @@ const out = {};
 
 // TODO/CR: should this be in its own file for consistency?
 out.PartialSubmission = Instance()(({ Submission }) => class {
-  complete(form, maybeActor, maybeDeviceId) {
+  complete(form, maybeActor, deviceId = null) {
     // TODO it's awkward that this error/message is thrown here; should be closer to edge.
     if (this.version !== form.version)
       throw Problem.user.unexpectedValue({ field: 'version', value: this.version, reason: 'The submission could not be accepted because your copy of this form is an outdated version. Please get the latest version and try again.' });
 
     const actorId = Option.of(maybeActor).map((actor) => actor.id).orNull();
-    const deviceId = blankStringToNull(maybeDeviceId);
+    const formattedDeviceId = blankStringToNull(deviceId);
     return new Submission(this.without('xmlFormId', 'version').with({
       formId: form.id,
       submitter: actorId,
-      deviceId
+      deviceId: formattedDeviceId
     }));
   }
 });

--- a/lib/model/migrations/20181230-01-add-device-id-to-submission.js
+++ b/lib/model/migrations/20181230-01-add-device-id-to-submission.js
@@ -13,7 +13,8 @@ const up = (knex) =>
   });
 
 const down = (knex) =>
-  knex.schema.table('submissions', (submissions) =>
-    submissions.dropColumn('deviceId'));
+  knex.schema.table('submissions', (submissions) => {
+    submissions.dropColumn('deviceId');
+  });
 
 module.exports = { up, down };

--- a/lib/model/migrations/20181230-01-add-device-id-to-submission.js
+++ b/lib/model/migrations/20181230-01-add-device-id-to-submission.js
@@ -1,0 +1,19 @@
+// Copyright 2018 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = (knex) =>
+  knex.schema.table('submissions', (submissions) => {
+    submissions.string('deviceId');
+  });
+
+const down = (knex) =>
+  knex.schema.table('submissions', (submissions) =>
+    submissions.dropColumn('deviceId'));
+
+module.exports = { up, down };

--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -44,7 +44,7 @@ module.exports = (service, endpoint) => {
       })));
 
   // Nonstandard REST; OpenRosa-specific API.
-  service.post('/projects/:projectId/submission', multipart.any(), endpoint.openRosa(({ all, Audit, Project, Submission }, { params, files, auth }) =>
+  service.post('/projects/:projectId/submission', multipart.any(), endpoint.openRosa(({ all, Audit, Project, Submission }, { params, files, auth, query }) =>
     // first, make sure the project exists, and that we have the right to submit to it.
     Project.getById(params.projectId)
       .then(getOrNotFound)
@@ -71,7 +71,7 @@ module.exports = (service, endpoint) => {
               .map((extant) => ((Buffer.compare(Buffer.from(extant.xml), Buffer.from(partial.xml)) !== 0)
                 ? reject(Problem.user.xmlConflict())
                 : extant))
-              .orElseGet(() => partial.complete(form, auth.actor()).create()))
+              .orElseGet(() => partial.complete(form, auth.actor(), query.deviceID).create()))
             // now we have a definite submission. we need to go through remaining fields
             // and attempt to add them all as files.
             .then((submission) => all.do(files


### PR DESCRIPTION
When a submission is created in the submission endpoint, the device id is now recorded using the deviceID query string property (used by Collect app).

More info: #150