### PR TITLE
new: add archived flag to project; expand invalidtype db error handling.

### DIFF
--- a/lib/model/instance/project.js
+++ b/lib/model/instance/project.js
@@ -18,7 +18,7 @@ const { withCreateTime, withUpdateTime } = require('../../util/instance');
 const ExtendedProject = ExtendedInstance({
   fields: {
     joined: [ 'forms', 'lastSubmission', 'appUsers' ],
-    readable: [ 'id', 'name', 'forms', 'lastSubmission', 'appUsers', 'createdAt', 'updatedAt' ]
+    readable: [ 'id', 'name', 'archived', 'forms', 'lastSubmission', 'appUsers', 'createdAt', 'updatedAt' ]
   },
   forApi() {
     const forms = this.forms || 0;
@@ -28,9 +28,9 @@ const ExtendedProject = ExtendedInstance({
 });
 
 module.exports = Instance.with(ActeeTrait('project'), HasExtended(ExtendedProject))('projects', {
-  all: [ 'id', 'name', 'acteeId', 'createdAt', 'updatedAt', 'deletedAt' ],
-  readable: [ 'id', 'name', 'createdAt', 'updatedAt' ],
-  writable: [ 'name' ]
+  all: [ 'id', 'name', 'archived', 'acteeId', 'createdAt', 'updatedAt', 'deletedAt' ],
+  readable: [ 'id', 'name', 'archived', 'createdAt', 'updatedAt' ],
+  writable: [ 'name', 'archived' ]
 })(({ simply, fieldKeys, projects }) => class {
   forCreate() { return withCreateTime(this); }
   create() { return projects.create(this); }

--- a/lib/model/migrations/20190405-01-add-project-archival-flag.js
+++ b/lib/model/migrations/20190405-01-add-project-archival-flag.js
@@ -1,0 +1,17 @@
+// Copyright 2019 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = (knex) =>
+  knex.schema.table('projects', (projects) => { projects.boolean('archived'); });
+
+const down = (knex) =>
+  knex.schema.table('projects', (projects) => { projects.dropColumn('archived'); });
+
+module.exports = { up, down };
+

--- a/lib/model/query/projects.js
+++ b/lib/model/query/projects.js
@@ -59,6 +59,7 @@ module.exports = {
       .where({ deletedAt: null })
       .where(options.condition)
       .modify(options.modify)
+      .orderBy(db.raw('coalesce(archived, false)'), 'asc')
       .orderBy('name')
       .then(rowsToInstances(Project))
     : db.select(fieldsForJoin({ project: Project.Extended }))
@@ -97,6 +98,7 @@ module.exports = {
           .as('assignments'),
         'assignments.acteeId', 'projects.acteeId'
       )
+      .orderBy(db.raw('coalesce(archived, false)'), 'asc')
       .orderBy('name')
       .then((rows) => rows.map(joinRowToInstance('project', {
         project: Project.Extended

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -203,10 +203,10 @@ const postgresErrorToProblem = (error) => {
       return reject(Problem.user.unexpectedAttribute({ field }));
     }
   } else if (error.code === '22P02') {
-    const match = /invalid input syntax for integer: "([^"]+)"/.exec(error.message);
+    const match = /invalid input syntax for ([\w ]+): "([^"]+)"/.exec(error.message);
     if (match != null) {
-      const [ , field ] = match;
-      return reject(Problem.user.invalidDataTypeOfParameter({ value: field, expected: 'integer' }));
+      const [ , expected, field ] = match;
+      return reject(Problem.user.invalidDataTypeOfParameter({ value: field, expected }));
     }
   }
 

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -71,7 +71,7 @@ const problems = {
 
     undecryptable: problem(400.10, () => 'Could not perform decryption. Double check your passphrase and try again.'),
 
-    invalidDataTypeOfParameter: problem(400.11, ({ value, expected }) => `Invalid data-type of '${value}' in url. Expected data-type (${expected})`),
+    invalidDataTypeOfParameter: problem(400.11, ({ value, expected }) => `Invalid input data type: expected '${value}' to be (${expected})`),
 
     // no detail information for security reasons.
     authenticationFailed: problem(401.2, () => 'Could not authenticate with the provided credentials.'),


### PR DESCRIPTION
* boolean flag on project. modifiable via PATCH.
* affects sorting on project listing; archived projects sort to the
  bottom, still alphabetized.
* false == null.
* also expand the 22P02 error handling to support more than integers,
  and genericize the error message to not mention a URL.