### PR TITLE
api/improve: use a 409 code rather than 400 on key conflict errors.

### DIFF
--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -53,10 +53,6 @@ const problems = {
     // { field: "the name of the extraneous parameter" }
     unexpectedAttribute: problem(400.4, ({ field }) => `Passed parameter ${field} was not expected.`),
 
-    // { field: "the unique field", value: "the supplied (conflicting) value",
-    //   table: "(optional) the table in question" }
-    uniquenessViolation: problem(400.5, ({ fields, values }) => `A resource already exists with ${fields} value(s) of ${values}.`),
-
     // { header: "the problematic header", value: "the supplied (problematic) value" }
     invalidHeader: problem(400.6, ({ field, value }) => `An expected header field (${field}) did not match the expected format (got: ${(value == null) ? '[nothing]' : value}).`),
 
@@ -97,7 +93,12 @@ const problems = {
     xmlConflict: problem(409.1, () => 'A submission already exists with this ID, but with different XML. Resubmissions to attach additional multimedia must resubmit an identical xml_submission_file.'),
 
     // form is not accepting submissions.
-    notAcceptingSubmissions: problem(409.2, () => 'This form is not currently accepting submissions. Please talk to your program staff if this is unexpected.')
+    notAcceptingSubmissions: problem(409.2, () => 'This form is not currently accepting submissions. Please talk to your program staff if this is unexpected.'),
+
+    // { field: "the unique field", value: "the supplied (conflicting) value",
+    //   table: "(optional) the table in question" }
+    uniquenessViolation: problem(409.3, ({ fields, values }) => `A resource already exists with ${fields} value(s) of ${values}.`)
+
   },
   internal: {
     // no detail information, as this is only called when we don't know what happened.

--- a/test/integration/api/forms.js
+++ b/test/integration/api/forms.js
@@ -185,9 +185,9 @@ describe('api: /projects/:id/forms', () => {
         asAlice.post('/v1/projects/1/forms')
           .send(testData.forms.simple)
           .set('Content-Type', 'application/xml')
-          .expect(400)
+          .expect(409)
           .then(({ body }) => {
-            body.code.should.equal(400.5);
+            body.code.should.equal(409.3);
             body.details.fields.should.eql([ 'xmlFormId', 'version', 'projectId' ]);
             body.details.values.should.eql([ 'simple', '', '1' ]);
           }))));
@@ -203,7 +203,7 @@ describe('api: /projects/:id/forms', () => {
           .then(() => asAlice.post('/v1/projects/1/forms')
             .send(testData.forms.simple)
             .set('Content-Type', 'application/xml')
-            .expect(400)
+            .expect(409)
             .then(({ body }) => {
               body.details.fields.should.eql([ 'xmlFormId', 'version', 'projectId' ]);
               body.details.values.should.eql([ 'simple', '', '1' ]);

--- a/test/unit/util/db.js
+++ b/test/unit/util/db.js
@@ -208,7 +208,7 @@ describe('util/db', () => {
 
     it('recognizes unique_violation', (done) => {
       postgresErrorToProblem(errorWith({ code: '23505', detail: 'Key (x)=(42) already exists.' })).catch((result) => {
-        result.problemCode.should.equal(400.5);
+        result.problemCode.should.equal(409.3);
         result.problemDetails.fields.should.eql([ 'x' ]);
         result.problemDetails.values.should.eql([ '42' ]);
         done();
@@ -217,7 +217,7 @@ describe('util/db', () => {
 
     it('recognizes and parses multi-column unique_violation', (done) => { // github #93
       postgresErrorToProblem(errorWith({ code: '23505', detail: 'Key ("xmlFormId", version)=(widgets, 1) already exists.' })).catch((result) => {
-        result.problemCode.should.equal(400.5);
+        result.problemCode.should.equal(409.3);
         result.problemDetails.fields.should.eql([ 'xmlFormId', 'version' ]);
         result.problemDetails.values.should.eql([ 'widgets', '1' ]);
         done();


### PR DESCRIPTION
* ie if a resource already exists.