### PR TITLE
bug+test: users should be allowed to view and edit their own profile.

### DIFF
--- a/lib/model/instance/actor.js
+++ b/lib/model/instance/actor.js
@@ -22,7 +22,7 @@
 
 const Instance = require('./instance');
 const Problem = require('../../util/problem');
-const { getOrReject } = require('../../util/promise');
+const { resolve, getOrReject } = require('../../util/promise');
 const { withCreateTime, withUpdateTime } = require('../../util/instance');
 
 const actorTypes = { system: 'system', user: 'user', group: 'group', proxy: 'proxy', singleUse: 'singleUse', fieldKey: 'fieldKey' };
@@ -67,7 +67,18 @@ module.exports = Instance('actors', {
 
   // returns a Promise[Boolean] indicating whether this Actor may perform
   // the given verb on the given Actee.
-  can(verb, actee) { return actors.can(this, verb, actee); }
+  can(verb, actee) {
+    if (this.acteeId === actee.acteeId) {
+      // rather than deal with granting every single user the row required to let them
+      // access/edit their own data, we just deal with it in code here.
+      // TODO: maybe this is a bad idea? i don't generally like code grants but it
+      // doesn't feel necessarily more foolproof to depend on the database being in sync here.
+      if ((verb === 'user.read') || (verb === 'user.update'))
+        return resolve(true);
+    }
+
+    return actors.can(this, verb, actee);
+  }
 
   // returns an array of verbs the Actor may perform on the given actee.
   verbsOn(actee) { return actors.verbsOn(this.id, actee); }


### PR DESCRIPTION
the background here is:

before we moved to role-based permissioning, there was [a clause in the code](https://github.com/opendatakit/central-backend/blob/be6f88b05b81b839154a3a07d56db0f46e7a7827/lib/model/instance/grant.js#L43) that did exactly this.

when we moved to the role-based version, it was half me not liking that exceptional clause and half me not thinking it through but it got dropped. as noted in the TODO comment now in the code, i've restored the line in code rather than solve it in the database because i think it's simpler and cleaner for now even if i don't like code-based grants when a database ACL system has been established.

on the other hand, this new incarnation is far more limited than the old one; the old one let users do anything at all to their own account; the new one only grants `user.read` and `user.update`.

there are three new tests that ensure nonadministrators can operate upon themselves.