### PR TITLE
bug+test: should send application/zip type with .csv.zip download.

### DIFF
--- a/lib/resources/submissions.js
+++ b/lib/resources/submissions.js
@@ -122,6 +122,7 @@ module.exports = (service, endpoint) => {
         ]).then(([ rows, attachments ]) => {
           const filename = sanitize(form.xmlFormId);
           response.append('Content-Disposition', `attachment; filename="${filename}.zip"`);
+          response.append('Content-Type', 'application/zip');
           return streamBriefcaseCsvs(rows, form).then((csvStream) =>
             zipStreamFromParts(csvStream, streamAttachments(attachments)));
         })))));

--- a/test/integration/api/submissions.js
+++ b/test/integration/api/submissions.js
@@ -372,6 +372,15 @@ describe('api: /forms/:id/submissions', () => {
   });
 
   describe('.csv.zip GET', () => {
+    it('should return a zipfile with the relevant headers', testService((service) =>
+      service.login('alice', (asAlice) =>
+        asAlice.get('/v1/projects/1/forms/simple/submissions.csv.zip')
+          .expect(200)
+          .then(({ headers }) => {
+            headers['content-disposition'].should.equal('attachment; filename="simple.zip"');
+            headers['content-type'].should.equal('application/zip');
+          }))));
+
     it('should return a zipfile with the relevant data', testService((service) =>
       service.login('alice', (asAlice) =>
         asAlice.post('/v1/projects/1/forms/simple/submissions')


### PR DESCRIPTION
* rather than the default application/json which causes safari to append
  .json to the filename.