### PR TITLE
bug #206: odata: provide null field markers vice omitting on no value.

### DIFF
--- a/lib/data/json.js
+++ b/lib/data/json.js
@@ -43,6 +43,19 @@ const getBranchState = (fieldStack, table) => {
   return -1;
 };
 
+// generates an initial databag for the given field.
+// (gh#206: we need to provide null fields for missing values, we can't just
+// leave them out. so we just initialize them all to null to start with.)
+const generateDataFrame = (children) => {
+  const frame = {};
+  for (const subkey of Object.keys(children)) {
+    const child = children[subkey];
+    if ((child.type !== 'structure') && (child.type !== 'repeat'))
+      frame[sanitizeOdataIdentifier(child.name)] = null;
+  }
+  return frame;
+};
+
 // rename ramda last to "ptr" to be more descriptive.
 const ptr = last;
 
@@ -77,7 +90,7 @@ const submissionToOData = (fields, table, { xml, submission, submitter }, option
 
   // we always build a tree structure from root to track where we are, even if
   // we are actually outputting some subtrees of it.
-  const root = { __id: submission.instanceId };
+  const root = Object.assign({ __id: submission.instanceId }, generateDataFrame(fields));
 
   if (table === 'Submissions') {
     // the instanceId and submission metadata we decorate onto every root row even
@@ -132,7 +145,7 @@ const submissionToOData = (fields, table, { xml, submission, submitter }, option
         if (field.type === 'structure') {
           // for structures, initialize an object if we haven't yet, then navigate into it.
           const dataPtr = ptr(dataStack);
-          if (dataPtr[outname] == null) dataPtr[outname] = {};
+          if (dataPtr[outname] == null) dataPtr[outname] = generateDataFrame(field.children);
           dataStack.push(dataPtr[outname]);
 
           // structures are part of the navigation stack but don't have iterations, so

--- a/test/unit/data/json.js
+++ b/test/unit/data/json.js
@@ -88,6 +88,52 @@ describe('submissionToOData', () => {
     });
   });
 
+  it('should output null field records for missing root atomic values', () => {
+    const fields = {
+      earth: { name: 'earth', type: 'int' },
+      mars: { name: 'mars', type: 'decimal' },
+      jupiter: { name: 'jupiter', type: 'geopoint' },
+      saturn: { name: 'saturn', type: 'structure', children: [] },
+      uranus: { name: 'uranus', type: 'repeat', children: [] }
+    };
+    const submission = mockSubmission('nulls', '<data><earth>42</earth></data>');
+    return submissionToOData(fields, 'Submissions', submission).then((result) => {
+      result.should.eql([{
+        __id: 'nulls',
+        __system,
+        earth: 42,
+        mars: null,
+        jupiter: null
+      }]);
+    });
+  });
+
+  it('should output null field records for missing nested atomic values', () => {
+    const fields = {
+      sun: { name: 'sun', type: 'structure',
+        children: {
+          earth: { name: 'earth', type: 'int' },
+          mars: { name: 'mars', type: 'decimal' },
+          jupiter: { name: 'jupiter', type: 'geopoint' },
+          saturn: { name: 'saturn', type: 'structure', children: [] },
+          uranus: { name: 'uranus', type: 'repeat', children: [] }
+        }
+      }
+    };
+    const submission = mockSubmission('nulls', '<data><sun><earth>42</earth></sun></data>');
+    return submissionToOData(fields, 'Submissions', submission).then((result) => {
+      result.should.eql([{
+        __id: 'nulls',
+        __system,
+        sun: {
+          earth: 42,
+          mars: null,
+          jupiter: null
+        }
+      }]);
+    });
+  });
+
   it('should sanitize fieldnames', () => {
     const fields = {
       'q1.8': { name: 'q1.8', type: 'string' },
@@ -155,7 +201,9 @@ describe('submissionToOData', () => {
     return submissionToOData(fields, 'Submissions', submission).then((result) => {
       result.should.eql([{
         __id: 'geo',
-        __system
+        __system,
+        geopointNoLon: null,
+        geopointNonsense: null
       }]);
     });
   });


### PR DESCRIPTION
* at least powerbi appears to interpret a missing field as an error
  rather than the lack of a value. so we provide all fields, and provide
  a null value.
* hopefully output gzip compression will save us the additional bits.
* closes #206.