### PR TITLE
improve #211: Sanitize pwd change requests sent to sentry

### DIFF
--- a/lib/util/sentry.js
+++ b/lib/util/sentry.js
@@ -1,5 +1,7 @@
 const { isBlank } = require('./util');
 
+const sensitiveEndpoints = ['/users/reset/verify', '/users/(.*?)/password'];
+
 const init = (config) => {
   if ((config == null) || isBlank(config.key) || isBlank(config.project)) {
     // return a noop object that returns the hooks but does nothing.
@@ -16,6 +18,14 @@ const init = (config) => {
   Sentry.init({
     dsn: `https://${config.key}@sentry.io/${config.project}`,
     beforeSend(event) {
+      if (event.request && event.request.url) {
+        for (const endpoint of sensitiveEndpoints) {
+          if (event.request.url.match(endpoint)) {
+            event.request.data = null;
+          }
+        }
+      }
+
       // only file the event if it is a bare exception or it is a true 500.x Problem.
       const error = event.extra.Error;
       if (error == null) return event; // we aren't sure why there isn't an exception; pass through.


### PR DESCRIPTION
This PR will resolve issue #211 

For sensitive endpoints, request payload will be set to `null` before the event is sent to sentry.