### PR TITLE
redo how draft submissions are discarded

### DIFF
--- a/lib/model/instance/form.js
+++ b/lib/model/instance/form.js
@@ -89,7 +89,7 @@ module.exports = Instance.with(
     'acteeId', 'createdAt', 'updatedAt', 'deletedAt' ],
   readable: [ 'projectId', 'xmlFormId', 'state', 'name', 'createdAt', 'updatedAt' ],
   writable: [ 'name', 'state' ]
-})(({ Project, forms, Form, FormPartial, simply }) => class {
+})(({ Project, forms, Form, FormPartial, simply, submissions }) => class {
 
   forUpdate() { return withUpdateTime(this.without('def')); }
   update() { return simply.update('forms', this); }
@@ -136,6 +136,8 @@ module.exports = Instance.with(
       () => Problem.user.versionUniquenessViolation({ xmlFormId: this.xmlFormId, version: this.def.version })
     ));
   }
+
+  clearDraftSubmissions() { return submissions.clearDraftSubmissions(this.id); }
 
   acceptsSubmissions() { return (this.state === 'open') || (this.state === 'closing'); }
 

--- a/lib/model/migrations/20200129-01-cascade-submission-deletes.js
+++ b/lib/model/migrations/20200129-01-cascade-submission-deletes.js
@@ -1,0 +1,33 @@
+// Copyright 2020 ODK Central Developers
+// See the NOTICE file at the top-level directory of this distribution and at
+// https://github.com/opendatakit/central-backend/blob/master/NOTICE.
+// This file is part of ODK Central. It is subject to the license terms in
+// the LICENSE file found in the top-level directory of this distribution and at
+// https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+// including this file, may be copied, modified, propagated, or distributed
+// except according to the terms contained in the LICENSE file.
+
+const up = async (db) => {
+  await db.schema.table('submission_defs', (sds) => {
+    sds.dropForeign('submissionId');
+    sds.foreign('submissionId').references('submissions.id').onDelete('cascade');
+  });
+  await db.schema.table('submission_attachments', (sas) => {
+    sas.dropForeign('submissionDefId');
+    sas.foreign('submissionDefId').references('submission_defs.id').onDelete('cascade');
+  });
+};
+
+const down = async (db) => {
+  await db.schema.table('submission_defs', (sds) => {
+    sds.dropForeign('submissionId');
+    sds.foreign('submissionId').references('submissions.id').onDelete('no action');
+  });
+  await db.schema.table('submission_attachments', (sas) => {
+    sas.dropForeign('submissionDefId');
+    sas.foreign('submissionDefId').references('submission_defs.id').onDelete('no action');
+  });
+};
+
+module.exports = { up, down };
+

--- a/lib/model/query/forms.js
+++ b/lib/model/query/forms.js
@@ -159,6 +159,7 @@ select id from form;`,
         .leftOuterJoin(
           db.select(db.raw('"formId", count(id)::integer as "submissions", max("createdAt") as "lastSubmission"'))
             .from('submissions')
+            .where({ draft: (version === Form.DraftVersion()) })
             .groupBy('formId')
             .as('submission_stats'),
           'forms.id', 'submission_stats.formId'

--- a/lib/model/query/keys.js
+++ b/lib/model/query/keys.js
@@ -31,16 +31,10 @@ select id from vals join keys using (public)`, [ key.public ])
           .innerJoin(
             db.select('formDefId')
               .from('submission_defs')
-              .modify((chain) => ((draft === true)
-                // the join will automatically filter down to the correct drafts; no need
-                // to check the flag.
-                ? chain.innerJoin('forms', 'forms.draftDefId', 'submission_defs.formDefId')
-                // otherwise, just check the flag.
-                : chain.innerJoin(
-                  db.select('submissions.id').from('submissions').where({ draft }).as('submissions'),
-                  'submissions.id', 'submission_defs.submissionId'
-                )
-              ))
+              .innerJoin(
+                db.select('submissions.id').from('submissions').where({ draft }).as('submissions'),
+                'submissions.id', 'submission_defs.submissionId'
+              )
               .innerJoin(
                 db.select(db.raw('max(id) as id'))
                   .from('submission_defs')

--- a/lib/model/query/submission-defs.js
+++ b/lib/model/query/submission-defs.js
@@ -25,18 +25,16 @@ module.exports = {
     db.select('submission_defs.*')
       .from('submission_defs')
       .innerJoin(
-        db.select('submissions.id', 'draftDefId').from('submissions')
+        db.select('submissions.id').from('submissions')
           .where({ instanceId, 'submissions.deletedAt': null, draft })
           .innerJoin(
-            db.select('id', 'draftDefId').from('forms')
+            db.select('id').from('forms')
               .where({ projectId, xmlFormId, deletedAt: null })
               .as('forms'),
             'forms.id', 'submissions.formId'
           )
           .as('submissions'),
-        ((draft === true)
-          ? { 'submissions.id': 'submission_defs.submissionId', 'submission_defs.formDefId': 'draftDefId' }
-          : { 'submissions.id': 'submission_defs.submissionId' })
+        'submissions.id', 'submission_defs.submissionId'
       )
       .orderBy('createdAt', 'desc')
       .limit(1)
@@ -76,10 +74,6 @@ module.exports = {
               .as('latest'),
             'submission_defs.id', 'latest.id'
           )
-          .modify((chain) => ((draft === true)
-            ? chain.innerJoin(db.select('draftDefId').from('forms').where({ id: formId }).as('forms'),
-              'forms.draftDefId', 'submission_defs.formDefId')
-            : chain))
           .innerJoin(db.select('*').from('submissions').where({ draft }).as('submissions'),
             'submissions.id', 'submission_defs.submissionId')
           .leftOuterJoin('actors', 'submissions.submitterId', 'actors.id')

--- a/lib/model/query/submissions.js
+++ b/lib/model/query/submissions.js
@@ -11,14 +11,6 @@ const { map } = require('ramda');
 const { withJoin, maybeFirst, rowsToInstances, QueryOptions, applyPagingOptions } = require('../../util/db');
 
 
-const applyDraftJoin = (draft) => (chain) => ((draft === true)
-  ? chain.innerJoin('forms', 'forms.id', 'submissions.formId')
-    .innerJoin('submission_defs', {
-      'submission_defs.submissionId': 'submissions.id',
-      'forms.draftDefId': 'submission_defs.formDefId'
-    })
-  : chain);
-
 module.exports = {
 
   // creates both the submission and its initial submission def in one go.
@@ -50,6 +42,9 @@ select ins.*, def.id as "submissionDefId" from ins, def;`,
       })
     })),
 
+  clearDraftSubmissions: (formId) => ({ db }) =>
+    db.delete().from('submissions').where({ formId, draft: true }),
+
   getById: (formId, instanceId, draft, options = QueryOptions.none) => ({ submissions }) =>
     submissions._get(formId, draft, options.withCondition({ instanceId })).then(maybeFirst),
 
@@ -63,7 +58,6 @@ select ins.*, def.id as "submissionDefId" from ins, def;`,
       .where({ formId, draft, 'submissions.deletedAt': null })
       .orderBy('submissions.id', 'desc')
       .modify(applyPagingOptions(options))
-      .modify(applyDraftJoin(draft))
       .then(rowsToInstances(Submission))
     : withJoin('submission', { submission: Submission.Extended, submitter: Actor }, (fields, unjoin) =>
       db.select(fields)
@@ -73,7 +67,6 @@ select ins.*, def.id as "submissionDefId" from ins, def;`,
         .leftOuterJoin('actors', 'actors.id', 'submissions.submitterId')
         .orderBy('submissions.id', 'desc')
         .modify(applyPagingOptions(options))
-        .modify(applyDraftJoin(draft))
         .then(map(unjoin))))
 };
 

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -48,7 +48,7 @@ module.exports = (service, endpoint) => {
       .then((forms) => formList({ forms, basePath: path.resolve(originalUrl, '..'), domain: env.domain }))));
 
   ////////////////////////////////////////////////////////////////////////////////
-  // FORM CREATION, DRAFT CREATION, DRAFT PUBLISH
+  // FORM CREATION, DRAFT CREATION / PUBLISH / DELETE
 
   // used by both POST /forms and POST /forms/:id/draft below; pulls in an xml or
   // xls file as appropriate, tacks on managed encryption if needed, and folds in
@@ -98,8 +98,11 @@ module.exports = (service, endpoint) => {
               ? reject(Problem.user.missingParameter({ field: 'xml' }))
               : getPartial(published.def.xml, project, FormPartial, Key)))
           : getPartial(request, project, FormPartial, Key)))
-        .then((partial) => partial.createVersion(form, false))
-        .then((savedDef) => Audit.log(auth.actor(), 'form.update.draft.set', form, { newDraftDefId: savedDef.id })))
+        .then((partial) => Promise.all([
+          partial.createVersion(form, false),
+          form.clearDraftSubmissions()
+        ]))
+        .then(([ savedDef ]) => Audit.log(auth.actor(), 'form.update.draft.set', form, { newDraftDefId: savedDef.id })))
       .then(success)));
 
   service.post('/projects/:projectId/forms/:id/draft/publish', endpoint(({ Audit, Form, FormPartial }, { params, auth, query }) =>
@@ -123,6 +126,7 @@ module.exports = (service, endpoint) => {
           : form)))
       .then(((form) => Promise.all([
         form.publish(),
+        form.clearDraftSubmissions(),
         Audit.log(auth.actor(), 'form.update.publish', form, { oldDefId: form.currentDefId, newDefId: form.draftDefId })
       ])))
       .then(success)));
@@ -138,6 +142,7 @@ module.exports = (service, endpoint) => {
       .then((form) => Promise.all([
         // TODO: for now we just cast away the draft to nothing. eventually probably sweep+delete.
         form.with({ draftDefId: null }).update(),
+        form.clearDraftSubmissions(),
         Audit.log(auth.actor(), 'form.update.draft.delete', form, { oldDraftDefId: form.draftDefId })
       ]))
       .then(success)));


### PR DESCRIPTION
in the previous PR, a lot of homework was done because old draft submissions would lay around (with `draft: false` in the database), and we had to do some extra comparisons to be sure we were only returning _current_ draft submissions.

here we instead hard-delete draft submissions any time a draft is created, published, or deleted. (we have to do created because drafts can be replaced without publishing or deleting them). this means all submissions are current, the only question is whether they are draft or not; so we can simplify all our queries to just check the boolean flag.

part of this work is to fix extended form responses; they were counting all submissions without handling draft/nondraft/olddraft at all. this has been corrected.