### PR TITLE
improve: draft formList: fix manifest node, use custom error message.

### DIFF
--- a/lib/model/instance/form.js
+++ b/lib/model/instance/form.js
@@ -32,7 +32,6 @@ const ChildTrait = require('../trait/child');
 const { ExtendedInstance, HasExtended } = require('../trait/extended');
 const { injectPublicKey, addVersionSuffix } = require('../../data/schema');
 const Option = require('../../util/option');
-const { translateProblem } = require('../../util/db');
 const { resolve, getOrNotFound } = require('../../util/promise');
 const { superproto } = require('../../util/util');
 const { withUpdateTime } = require('../../util/instance');
@@ -137,7 +136,7 @@ module.exports = Instance.with(
     return Promise.all([
       this.with({ currentDefId: this.draftDefId, draftDefId: null }).update(),
       this.def.with({ draftToken: null, publishedAt: new Date() }).update()
-    ]).catch(translateProblem(
+    ]).catch(Problem.translate(
       Problem.user.uniquenessViolation,
       () => Problem.user.versionUniquenessViolation({ xmlFormId: this.xmlFormId, version: this.def.version })
     ));

--- a/lib/resources/forms.js
+++ b/lib/resources/forms.js
@@ -323,18 +323,26 @@ module.exports = (service, endpoint) => {
   // TODO: copied from resources/submissions
   const checkFormToken = (token) => rejectIf(
     ((form) => (form.def.draftToken !== token) || isBlank(form.def.draftToken)),
-    Problem.user.notFound
+    () => Problem.user.notFound()
   );
 
-  service.get('/test/:key/projects/:projectId/forms/:id/draft/formList', endpoint.openRosa(({ Form, env }, { params, originalUrl }) =>
+  service.get('/test/:key/projects/:projectId/forms/:id/draft/formList', endpoint.openRosa(({ Form, FormAttachment, env }, { params, originalUrl }) =>
     Form.getByProjectAndXmlFormId(params.projectId, params.id, undefined, Form.DraftVersion())
       .then(getOrNotFound)
       .then(ensureDef)
       .then(checkFormToken(params.key))
-      .then((form) => formList({
-        // TODO: trying to use the existing template generator here is really awkward.
-        draft: true, forms: [ form ], basePath: path.resolve(originalUrl, '../../../..'), domain: env.domain
-      }))));
+      .catch(Problem.translate(
+        Problem.user.notFound,
+        () => Problem.user.failedDraftAccess()
+      ))
+      // TODO: this is really awful. extra request to munge in a value.
+      .then((form) => FormAttachment.getAllByFormDefIdForOpenRosa(form.def.id)
+        .then((attachments) => attachments.length > 0)
+        .then((hasAttachments) =>
+          // TODO: trying to use the existing template generator here is really awkward.
+          formList({
+            draft: true, forms: [ form.with({ hasAttachments }) ], basePath: path.resolve(originalUrl, '../../../..'), domain: env.domain
+          })))));
 
   service.get('/test/:key/projects/:projectId/forms/:id/draft/manifest', endpoint.openRosa(({ FormAttachment, Form, env }, { params, originalUrl }) =>
     Form.getByProjectAndXmlFormId(params.projectId, params.id, undefined, Form.DraftVersion())

--- a/lib/util/db.js
+++ b/lib/util/db.js
@@ -301,16 +301,11 @@ const postgresErrorToProblem = (error) => {
   return reject(error);
 };
 
-// Squares away some boilerplate for translating problems into other ones in cases
-// where the immediate translation of the database error is cryptic.
-const translateProblem = (type, result) => (problem) =>
-  reject((problem.problemCode === type.code) ? result(problem) : problem);
-
 
 module.exports = {
   withJoin,
   QueryOptions, applyPagingOptions, ifArg,
   rowToInstance, maybeRowToInstance, rowsToInstances, maybeFirst, wasUpdateSuccessful, resultCount,
-  postgresErrorToProblem, translateProblem
+  postgresErrorToProblem
 };
 

--- a/lib/util/problem.js
+++ b/lib/util/problem.js
@@ -32,6 +32,12 @@ class Problem extends Error {
       ? { message: error.message, stack: error.stack, code: error.problemCode, details: error.problemDetails }
       : { message: error.message, stack: error.stack };
   }
+
+  static translate(type, result) {
+    return (problem) =>
+      // we don't import util/promise for reject because it'd cause a loop
+      Promise.reject((problem.problemCode === type.code) ? result(problem) : problem);
+  }
 }
 
 // Simplifies some boilerplate for the next block of code.
@@ -98,6 +104,9 @@ const problems = {
 
     // unexpected API version.
     unexpectedApiVersion: problem(404.3, ({ got }) => `Unexpected an API version (accepts: 1) (got: ${got}).`),
+
+    // failed draft access.
+    failedDraftAccess: problem(404.4, () => 'You tried to access a draft testing endpoint, but it does not exist anymore or your access is no longer valid. If the form has been published and you would like to submit to it, you should configure your device with an App User token. If there is a new draft, you may have to reconfigure your device from the draft settings.'),
 
     // { allowed: [ acceptable formats ], got }
     unacceptableFormat: problem(406.1, ({ allowed }) => `Requested format not acceptable; this resource allows: ${allowed.join()}.`),


### PR DESCRIPTION
* we weren't getting attachments so the manifest node never appeared.
* also a 404 on this endpoint will always yield a custom message that
  carries a different hint on what might be wrong.